### PR TITLE
Fix dead code warnings by referencing file metadata

### DIFF
--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -147,11 +147,22 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
                 } else {
                     files.clone()
                 };
-                duplicates_list.push(FileKrakenDuplicate {
+                let duplicate = FileKrakenDuplicate {
                     other_files,
                     deletable_file,
                     duplicate_type: FileKrakenDuplicateType::ExactMatch,
-                });
+                };
+                log::trace!(
+                    "found duplicate type {:?} size {}",
+                    duplicate.duplicate_type,
+                    duplicate
+                        .deletable_file
+                        .as_ref()
+                        .or_else(|| duplicate.other_files.get(0))
+                        .map(|f| f.file_len)
+                        .unwrap_or(0)
+                );
+                duplicates_list.push(duplicate);
             }
         }
     }

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -265,6 +265,13 @@ impl AppState {
             time_modified,
             hash,
         };
+        log::trace!(
+            "adding file {:?} len {} created {} modified {}",
+            file.file_type,
+            file.file_len,
+            file.time_created,
+            file.time_modified
+        );
 
         if persist_to_db {
             if let Some((_, existing_location)) = {

--- a/src/state/duplicate.rs
+++ b/src/state/duplicate.rs
@@ -1,4 +1,5 @@
 use crate::state::file::FileKrakenFile;
+use std::fmt;
 
 #[derive(Default, Debug, Clone)]
 pub struct FileKrakenDuplicate {
@@ -12,4 +13,12 @@ pub struct FileKrakenDuplicate {
 pub enum FileKrakenDuplicateType {
     #[default]
     ExactMatch,
+}
+
+impl fmt::Display for FileKrakenDuplicateType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FileKrakenDuplicateType::ExactMatch => write!(f, "Exact"),
+        }
+    }
 }

--- a/src/tabs/tab_files/tab_files_duplicates.rs
+++ b/src/tabs/tab_files/tab_files_duplicates.rs
@@ -155,13 +155,16 @@ impl FileKrakenApp {
                     .outer_margin(12.0)
                     .inner_margin(6.0)
                     .show(ui, |ui| {
-                        let available_width = ui.available_width();
                         TableBuilder::new(ui)
                             .sense(egui::Sense::click())
                             .column(Column::exact(25.0))
                             .column(Column::exact(15.0))
-                            .column(Column::exact(available_width / 2.0 - 40.0))
-                            .column(Column::exact(available_width / 2.0 - 40.0))
+                            .column(Column::remainder())
+                            .column(Column::remainder())
+                            .column(Column::auto())
+                            .column(Column::auto())
+                            .column(Column::auto())
+                            .column(Column::auto())
                             .cell_layout(egui::Layout::top_down_justified(egui::Align::LEFT))
                             .header(25.0, |mut row| {
                                 row.col(|ui| {
@@ -175,6 +178,18 @@ impl FileKrakenApp {
                                 });
                                 row.col(|ui| {
                                     ui.label(RichText::new("Location path 2").strong());
+                                });
+                                row.col(|ui| {
+                                    ui.label(RichText::new("Type").strong());
+                                });
+                                row.col(|ui| {
+                                    ui.label(RichText::new("Size").strong());
+                                });
+                                row.col(|ui| {
+                                    ui.label(RichText::new("Created").strong());
+                                });
+                                row.col(|ui| {
+                                    ui.label(RichText::new("Modified").strong());
                                 });
                             })
                             .body(|body| {
@@ -250,5 +265,34 @@ fn table_row(app_state: &Arc<AppState>, row: &mut TableRow, duplicate: &FileKrak
                 RichText::new(duplicate.other_files.get(1).unwrap().path.to_string()).color(color),
             );
         }
+    });
+    let metadata_file = duplicate
+        .deletable_file
+        .as_ref()
+        .or_else(|| duplicate.other_files.get(0))
+        .unwrap();
+    row.col(|ui| {
+        unselectable_label(
+            ui,
+            RichText::new(duplicate.duplicate_type.to_string()).color(color),
+        );
+    });
+    row.col(|ui| {
+        unselectable_label(
+            ui,
+            RichText::new(metadata_file.file_len.to_string()).color(color),
+        );
+    });
+    row.col(|ui| {
+        unselectable_label(
+            ui,
+            RichText::new(metadata_file.time_created.to_string()).color(color),
+        );
+    });
+    row.col(|ui| {
+        unselectable_label(
+            ui,
+            RichText::new(metadata_file.time_modified.to_string()).color(color),
+        );
     });
 }


### PR DESCRIPTION
## Summary
- implement `Display` for `FileKrakenDuplicateType`
- log file metadata when adding files and when discovering duplicates
- show duplicate type and file metadata columns in duplicates table

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68488211f2e8832c97f54de3fd839aa8