### PR TITLE
Improve error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,11 @@ impl eframe::App for FileKrakenApp {
                                     .pick_file();
 
                                 if let Some(file) = maybe_file {
-                                    try_connect_sqlite(self, file.to_str().unwrap());
+                                    if let Some(path) = file.to_str() {
+                                        try_connect_sqlite(self, path);
+                                    } else {
+                                        error_dialog("Invalid project path");
+                                    }
                                 }
                             }
                             ui.add_space(8.0);
@@ -80,7 +84,11 @@ impl eframe::App for FileKrakenApp {
                                     if !file.ends_with(".fkrproj") {
                                         file.set_extension("fkrproj");
                                     }
-                                    try_connect_sqlite(self, file.to_str().unwrap());
+                                    if let Some(path) = file.to_str() {
+                                        try_connect_sqlite(self, path);
+                                    } else {
+                                        error_dialog("Invalid project path");
+                                    }
                                 }
                             }
                         });

--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -3,10 +3,11 @@ use crate::state::file::{FileKrakenFile, FileKrakenFileType};
 use crate::state::location::{FileKrakenLocation, FileKrakenLocationType};
 use crate::state::AppState;
 use crate::utils::get_longest_parent_path;
+use crate::utils::locks::{lock_rw_read_or_close, lock_rw_write_or_close};
 use egui::ahash::HashMap;
 use std::cmp::max;
 use std::ops::DerefMut;
-use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockWriteGuard};
 
 #[derive(Default)]
 pub struct FindDuplicatesState {
@@ -48,15 +49,16 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
             .show();
         return Some(());
     }
-    app_state
-        .find_duplicates_processing
-        .duplicates
-        .write()
-        .ok()?
-        .clear();
+    if let Some(mut dups) =
+        lock_rw_write_or_close(&app_state.find_duplicates_processing.duplicates, &app_state)
+    {
+        dups.clear();
+    } else {
+        return None;
+    }
 
     set_processing_message(&app_state, "Scanning for file size matches...".to_string());
-    let mut duplicate_file_sizes = find_duplicate_file_sizes(&app_state.sqlite)?;
+    let mut duplicate_file_sizes = find_duplicate_file_sizes(&app_state)?;
 
     let files_by_size_by_hash = Arc::new(RwLock::new(HashMap::default()));
     let mut duplicates_search_by_filesize_threads = vec![];
@@ -74,7 +76,8 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
         let sizes_checked_so_far = sizes_checked_so_far.clone();
         duplicates_search_by_filesize_threads.push(std::thread::spawn(move || {
             for duplicate_file_size in duplicate_file_size_chunk {
-                let Some(mut files_by_size) = get_files_by_size(&app_state, duplicate_file_size) else {
+                let Some(mut files_by_size) = get_files_by_size(&app_state, duplicate_file_size)
+                else {
                     continue;
                 };
                 let nr_files_by_size = files_by_size.len();
@@ -131,15 +134,26 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
         &app_state,
         "Checking file-hashes for duplicates...".to_string(),
     );
-    let files_by_size_by_hash_lock = files_by_size_by_hash.write().ok()?;
+    let files_by_size_by_hash_lock =
+        match lock_rw_write_or_close(&files_by_size_by_hash, &app_state) {
+            Some(lock) => lock,
+            None => return None,
+        };
     for (_, files_by_size) in files_by_size_by_hash_lock.iter() {
-        for (_, files) in files_by_size.read().ok()?.iter() {
+        for (_, files) in match lock_rw_read_or_close(files_by_size, &app_state) {
+            Some(l) => l,
+            None => return None,
+        }
+        .iter()
+        {
             if files.len() > 1 {
-                let mut duplicates_list = app_state
-                    .find_duplicates_processing
-                    .duplicates
-                    .write()
-                    .ok()?;
+                let mut duplicates_list = match lock_rw_write_or_close(
+                    &app_state.find_duplicates_processing.duplicates,
+                    &app_state,
+                ) {
+                    Some(lock) => lock,
+                    None => return None,
+                };
 
                 let deletable_file = get_deletable_file(&app_state, &files);
                 let other_files = if let Some(ref deletable) = deletable_file {
@@ -214,7 +228,7 @@ fn get_deletable_file(
 }
 
 fn get_files_by_size(app_state: &Arc<AppState>, size: u64) -> Option<Vec<FileKrakenFile>> {
-    let sqlite_lock = app_state.sqlite.lock().ok()?;
+    let sqlite_lock = app_state.sqlite_lock_or_close()?;
     let mut files = vec![];
 
     let mut sqlite_query = sqlite_lock
@@ -262,10 +276,8 @@ pub fn set_processing_message(app_state: &Arc<AppState>, message: String) {
         FindDuplicatesStateType::Processing(message);
 }
 
-fn find_duplicate_file_sizes(
-    sqlite: &Arc<Mutex<Option<rusqlite::Connection>>>,
-) -> Option<Vec<u64>> {
-    let sqlite_lock = sqlite.lock().ok()?;
+fn find_duplicate_file_sizes(app_state: &Arc<AppState>) -> Option<Vec<u64>> {
+    let sqlite_lock = app_state.sqlite_lock_or_close()?;
     let mut find_duplicate_file_sizes = sqlite_lock
         .as_ref()?
         .prepare("SELECT file_len, COUNT(*) c FROM files f GROUP BY file_len HAVING c > 1")

--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -74,8 +74,9 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
         let sizes_checked_so_far = sizes_checked_so_far.clone();
         duplicates_search_by_filesize_threads.push(std::thread::spawn(move || {
             for duplicate_file_size in duplicate_file_size_chunk {
-                let mut files_by_size: Vec<FileKrakenFile> =
-                    get_files_by_size(&app_state, duplicate_file_size).unwrap();
+                let Some(mut files_by_size) = get_files_by_size(&app_state, duplicate_file_size) else {
+                    continue;
+                };
                 let nr_files_by_size = files_by_size.len();
                 set_processing_message(
                     &app_state,
@@ -101,19 +102,22 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
                     let _app_state = app_state.clone();
                     threads.push(std::thread::spawn(move || {
                         for mut file in files {
-                            // calc hash
-                            file.hash = Some(_app_state.calculate_file_hash(&file.path));
-                            files_by_size_by_hash
-                                .write()
-                                .unwrap()
-                                .entry(file.hash.clone().unwrap())
-                                .or_insert(vec![])
-                                .push(file.clone());
+                            if let Some(hash) = _app_state.calculate_file_hash(&file.path) {
+                                file.hash = Some(hash.clone());
+                                files_by_size_by_hash
+                                    .write()
+                                    .unwrap()
+                                    .entry(hash)
+                                    .or_insert(vec![])
+                                    .push(file.clone());
+                            }
                         }
                     }));
                 }
                 for thread in threads {
-                    thread.join().expect("Failed to join hashing thread");
+                    if let Err(err) = thread.join() {
+                        log::error!("Hashing thread panicked: {:?}", err);
+                    }
                 }
                 *sizes_checked_so_far.write().unwrap() += 1.0;
             }
@@ -138,10 +142,10 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
                     .ok()?;
 
                 let deletable_file = get_deletable_file(&app_state, &files);
-                let other_files = if deletable_file.is_some() {
+                let other_files = if let Some(ref deletable) = deletable_file {
                     files
                         .iter()
-                        .filter(|x| x.path != deletable_file.as_ref().unwrap().path)
+                        .filter(|x| x.path != deletable.path)
                         .cloned()
                         .collect()
                 } else {
@@ -174,7 +178,7 @@ fn get_deletable_file(
                     (
                         file.clone(),
                         get_longest_parent_path(&file.path, locations.iter())
-                            .map(|x| locations.iter().find(|loc| loc.path == x).unwrap().clone()),
+                            .and_then(|p| locations.iter().find(|loc| loc.path == p).cloned()),
                     )
                 })
                 .collect()
@@ -210,7 +214,7 @@ fn get_deletable_file(
 }
 
 fn get_files_by_size(app_state: &Arc<AppState>, size: u64) -> Option<Vec<FileKrakenFile>> {
-    let sqlite_lock = app_state.sqlite.lock().unwrap();
+    let sqlite_lock = app_state.sqlite.lock().ok()?;
     let mut files = vec![];
 
     let mut sqlite_query = sqlite_lock
@@ -221,7 +225,7 @@ fn get_files_by_size(app_state: &Arc<AppState>, size: u64) -> Option<Vec<FileKra
         FROM files \
         WHERE file_len = ?1",
         )
-        .unwrap();
+        .ok()?;
     let mut select_files = sqlite_query.query([size]).ok()?;
 
     while let Some(row) = select_files.next().ok()? {
@@ -261,10 +265,9 @@ pub fn set_processing_message(app_state: &Arc<AppState>, message: String) {
 fn find_duplicate_file_sizes(
     sqlite: &Arc<Mutex<Option<rusqlite::Connection>>>,
 ) -> Option<Vec<u64>> {
-    let sqlite_lock = sqlite.lock().unwrap();
+    let sqlite_lock = sqlite.lock().ok()?;
     let mut find_duplicate_file_sizes = sqlite_lock
-        .as_ref()
-        .unwrap()
+        .as_ref()?
         .prepare("SELECT file_len, COUNT(*) c FROM files f GROUP BY file_len HAVING c > 1")
         .ok()?;
     let mut find_duplicate_file_sizes_query = find_duplicate_file_sizes.query([]).ok()?;
@@ -286,14 +289,19 @@ pub fn delete_duplicate(app_state: &Arc<AppState>, duplicate: &FileKrakenDuplica
             .read()
             .unwrap();
 
-        duplicates_list
-            .iter()
-            .position(|x| {
-                x.deletable_file.as_ref().is_some_and(|file| {
-                    file.path == duplicate.deletable_file.as_ref().unwrap().path
-                })
+        match duplicates_list.iter().position(|x| {
+            x.deletable_file.as_ref().is_some_and(|file| {
+                duplicate
+                    .deletable_file
+                    .as_ref()
+                    .map(|d| d.path.as_str())
+                    .unwrap_or("")
+                    == file.path
             })
-            .unwrap()
+        }) {
+            Some(index) => index,
+            None => return,
+        }
     };
     {
         app_state
@@ -304,5 +312,7 @@ pub fn delete_duplicate(app_state: &Arc<AppState>, duplicate: &FileKrakenDuplica
             .remove(duplicate_index);
     }
 
-    app_state.remove_file(true, true, &duplicate.deletable_file.as_ref().unwrap().path);
+    if let Some(file) = duplicate.deletable_file.as_ref() {
+        app_state.remove_file(true, true, &file.path);
+    }
 }

--- a/src/processing/scan.rs
+++ b/src/processing/scan.rs
@@ -93,27 +93,43 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
     }
 
     // check if files were removed
-    let files: Vec<String> = {
-        if let Some(sqlite_lock) = app_state.sqlite_lock_or_close() {
-            if let Some(conn) = sqlite_lock.as_ref() {
-                if let Ok(mut files_query) =
-                    conn.prepare("SELECT path FROM files WHERE location_path = ?")
-                {
-                    if let Ok(rows) = files_query.query_map(&[&location_path], |row| row.get(0)) {
-                        rows.filter_map(|x| x.ok()).collect()
-                    } else {
-                        vec![]
-                    }
-                } else {
-                    vec![]
-                }
-            } else {
-                vec![]
-            }
-        } else {
-            vec![]
+    // A failure to query the database here means the project state is no longer
+    // trustworthy. Notify the user and close the project on any error.
+    let mut files = Vec::new();
+    let sqlite_lock = match app_state.sqlite_lock_or_close() {
+        Some(l) => l,
+        None => return,
+    };
+    let conn = match sqlite_lock.as_ref() {
+        Some(c) => c,
+        None => {
+            error_dialog("Internal error: database connection missing. Closing project.");
+            app_state.close_project();
+            return;
         }
     };
+
+    let mut files_query = match conn.prepare("SELECT path FROM files WHERE location_path = ?") {
+        Ok(q) => q,
+        Err(err) => {
+            error_dialog(&format!("Failed to query database: {err}. Closing project."));
+            app_state.close_project();
+            return;
+        }
+    };
+
+    let rows = match files_query.query_map(&[&location_path], |row| row.get(0)) {
+        Ok(rows) => rows,
+        Err(err) => {
+            error_dialog(&format!("Failed to read from database: {err}. Closing project."));
+            app_state.close_project();
+            return;
+        }
+    };
+    files.extend(rows.filter_map(|x| x.ok()));
+    drop(files_query);
+    drop(sqlite_lock);
+    let files: Vec<String> = files;
     for file in files {
         // check filesystem
         if !std::path::Path::new(&file).exists() {

--- a/src/processing/scan.rs
+++ b/src/processing/scan.rs
@@ -8,10 +8,13 @@ use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
 pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
-    let current_state = app_state
-        .get_location_clone(location_path)
-        .unwrap()
-        .location_state;
+    let current_state = match app_state.get_location_clone(location_path) {
+        Some(loc) => loc.location_state,
+        None => {
+            error_dialog(&format!("Location {location_path} not found"));
+            return;
+        }
+    };
     if current_state == FileKrakenLocationState::Scanning {
         return error_dialog("Already scanning this location");
     }
@@ -32,10 +35,17 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
                 } else {
                     FileKrakenFileType::Normal
                 };
-                let file_metadata = entry.metadata().expect(&format!(
-                    "Failed to get file metadata for file {:?}",
-                    entry.path()
-                ));
+                let file_metadata = match entry.metadata() {
+                    Ok(meta) => meta,
+                    Err(err) => {
+                        error!(
+                            "Failed to get file metadata for file {:?}: {}",
+                            entry.path(),
+                            err
+                        );
+                        continue;
+                    }
+                };
 
                 if let Some(file_path) = entry.path().to_str() {
                     app_state.add_file(
@@ -45,15 +55,15 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
                         file_metadata.len(),
                         file_metadata
                             .created()
-                            .unwrap()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or(std::time::Duration::new(0, 0))
+                            .ok()
+                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                            .unwrap_or_default()
                             .as_secs(),
                         file_metadata
                             .modified()
-                            .unwrap()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or(std::time::Duration::new(0, 0))
+                            .ok()
+                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                            .unwrap_or_default()
                             .as_secs(),
                         None,
                     );
@@ -84,17 +94,25 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
 
     // check if files were removed
     let files: Vec<String> = {
-        let sqlite_lock = app_state.sqlite.lock().unwrap();
-        let mut files_query = sqlite_lock
-            .as_ref()
-            .unwrap()
-            .prepare("SELECT path FROM files WHERE location_path = ?")
-            .unwrap();
-        files_query
-            .query_map(&[&location_path], |row| row.get(0))
-            .unwrap()
-            .map(|x| x.unwrap())
-            .collect()
+        if let Ok(sqlite_lock) = app_state.sqlite.lock() {
+            if let Some(conn) = sqlite_lock.as_ref() {
+                if let Ok(mut files_query) =
+                    conn.prepare("SELECT path FROM files WHERE location_path = ?")
+                {
+                    if let Ok(rows) = files_query.query_map(&[&location_path], |row| row.get(0)) {
+                        rows.filter_map(|x| x.ok()).collect()
+                    } else {
+                        vec![]
+                    }
+                } else {
+                    vec![]
+                }
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        }
     };
     for file in files {
         // check filesystem

--- a/src/processing/scan.rs
+++ b/src/processing/scan.rs
@@ -94,7 +94,7 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
 
     // check if files were removed
     let files: Vec<String> = {
-        if let Ok(sqlite_lock) = app_state.sqlite.lock() {
+        if let Some(sqlite_lock) = app_state.sqlite_lock_or_close() {
             if let Some(conn) = sqlite_lock.as_ref() {
                 if let Ok(mut files_query) =
                     conn.prepare("SELECT path FROM files WHERE location_path = ?")

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -1,9 +1,9 @@
-use crate::processing::find_duplicates::FindDuplicatesState;
+use crate::processing::find_duplicates::{FindDuplicatesState, FindDuplicatesStateType};
 use crate::state::file::{FileKrakenFile, FileKrakenFileType};
 use crate::state::location::{FileKrakenLocation, FileKrakenLocationState, FileKrakenLocationType};
+use crate::utils::dialogs::error_dialog;
 use crate::utils::get_longest_parent_path;
 use crate::utils::hashing::hash_file;
-use crate::utils::dialogs::error_dialog;
 use std::collections::HashMap;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
@@ -121,12 +121,24 @@ impl AppState {
         Ok(())
     }
 
+    /// Acquire the SQLite connection mutex or close the project on failure.
+    pub fn sqlite_lock_or_close(
+        &self,
+    ) -> Option<std::sync::MutexGuard<'_, Option<rusqlite::Connection>>> {
+        match self.sqlite.lock() {
+            Ok(g) => Some(g),
+            Err(_) => {
+                error_dialog("Internal error: database lock poisoned. Closing project.");
+                self.close_project();
+                None
+            }
+        }
+    }
+
     pub fn calculate_file_hash(&self, file_path: &str) -> Option<String> {
         // get file to check if its already hashed
         let hash: String = self
-            .sqlite
-            .lock()
-            .ok()?
+            .sqlite_lock_or_close()?
             .as_ref()?
             .query_row(
                 "SELECT hash_256 FROM files WHERE path = ?1;",
@@ -138,7 +150,7 @@ impl AppState {
         if hash == "NULL" {
             match hash_file(file_path) {
                 Ok(hash) => {
-                    if let Ok(sqlite_lock) = self.sqlite.lock() {
+                    if let Some(sqlite_lock) = self.sqlite_lock_or_close() {
                         if let Some(conn) = sqlite_lock.as_ref() {
                             let _ = conn.execute(
                                 "UPDATE files SET hash_256 = ?1 WHERE path = ?2;",
@@ -520,5 +532,24 @@ impl AppState {
             .get(location)
             // clone the Arc reference of the Hashmap if it exists
             .map(|x| x.clone())
+    }
+
+    /// Close the currently open project and clear all in-memory state.
+    pub fn close_project(&self) {
+        if let Ok(mut sqlite) = self.sqlite.lock() {
+            *sqlite = None;
+        }
+        if let Ok(mut locations) = self.locations_list.write() {
+            locations.clear();
+        }
+        if let Ok(mut files) = self.files_by_location_by_path.write() {
+            files.clear();
+        }
+        if let Ok(mut dups) = self.find_duplicates_processing.duplicates.write() {
+            dups.clear();
+        }
+        if let Ok(mut state) = self.find_duplicates_processing.state.write() {
+            *state = FindDuplicatesStateType::None;
+        }
     }
 }

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -3,6 +3,7 @@ use crate::state::file::{FileKrakenFile, FileKrakenFileType};
 use crate::state::location::{FileKrakenLocation, FileKrakenLocationState, FileKrakenLocationType};
 use crate::utils::get_longest_parent_path;
 use crate::utils::hashing::hash_file;
+use crate::utils::dialogs::error_dialog;
 use std::collections::HashMap;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
@@ -120,41 +121,40 @@ impl AppState {
         Ok(())
     }
 
-    pub fn calculate_file_hash(&self, file_path: &str) -> String {
+    pub fn calculate_file_hash(&self, file_path: &str) -> Option<String> {
         // get file to check if its already hashed
         let hash: String = self
             .sqlite
             .lock()
-            .unwrap()
-            .as_ref()
-            .expect("sqlite connection not set")
+            .ok()?
+            .as_ref()?
             .query_row(
                 "SELECT hash_256 FROM files WHERE path = ?1;",
                 [file_path],
                 |x| x.get(0),
             )
-            .unwrap();
+            .ok()?;
 
-        match hash.as_str() {
-            "NULL" => {
-                // calculate hash
-                let hash = hash_file(&file_path);
-
-                // update hash in sqlite
-                self.sqlite
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .expect("sqlite connection not set")
-                    .execute(
-                        "UPDATE files SET hash_256 = ?1 WHERE path = ?2;",
-                        [&hash, file_path],
-                    )
-                    .unwrap();
-
-                hash
+        if hash == "NULL" {
+            match hash_file(file_path) {
+                Ok(hash) => {
+                    if let Ok(sqlite_lock) = self.sqlite.lock() {
+                        if let Some(conn) = sqlite_lock.as_ref() {
+                            let _ = conn.execute(
+                                "UPDATE files SET hash_256 = ?1 WHERE path = ?2;",
+                                [&hash, file_path],
+                            );
+                        }
+                    }
+                    Some(hash)
+                }
+                Err(err) => {
+                    error_dialog(&format!("Failed to hash file {file_path}: {err}"));
+                    None
+                }
             }
-            x => x.to_string(),
+        } else {
+            Some(hash)
         }
     }
 

--- a/src/utils/hashing.rs
+++ b/src/utils/hashing.rs
@@ -1,12 +1,14 @@
 use sha2::{Digest, Sha256};
 use std::{fs, io};
 
-pub fn hash_file(file_path: &str) -> String {
+/// Calculate the SHA256 hash of a file.
+///
+/// Instead of panicking on IO errors, this function now
+/// returns a `Result` so callers can react appropriately.
+pub fn hash_file(file_path: &str) -> io::Result<String> {
     let mut hasher = Sha256::new();
-    let mut file =
-        fs::File::open(file_path).expect(&format!("Failed to open file {:?}", file_path));
-    let _bytes_written =
-        io::copy(&mut file, &mut hasher).expect(&format!("Failed to hash file {:?}", file_path));
+    let mut file = fs::File::open(file_path)?;
+    io::copy(&mut file, &mut hasher)?;
 
-    format!("{:X}", hasher.finalize())
+    Ok(format!("{:X}", hasher.finalize()))
 }

--- a/src/utils/locks.rs
+++ b/src/utils/locks.rs
@@ -1,0 +1,31 @@
+use crate::state::AppState;
+use crate::utils::dialogs::error_dialog;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+pub fn lock_rw_write_or_close<'a, T>(
+    lock: &'a RwLock<T>,
+    app_state: &AppState,
+) -> Option<RwLockWriteGuard<'a, T>> {
+    match lock.write() {
+        Ok(guard) => Some(guard),
+        Err(_) => {
+            error_dialog("Internal error: lock poisoned. Closing project.");
+            app_state.close_project();
+            None
+        }
+    }
+}
+
+pub fn lock_rw_read_or_close<'a, T>(
+    lock: &'a RwLock<T>,
+    app_state: &AppState,
+) -> Option<RwLockReadGuard<'a, T>> {
+    match lock.read() {
+        Ok(guard) => Some(guard),
+        Err(_) => {
+            error_dialog("Internal error: lock poisoned. Closing project.");
+            app_state.close_project();
+            None
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod dialogs;
 pub mod hashing;
+pub mod locks;
 mod parent_path;
 pub mod ui_elements;
 


### PR DESCRIPTION
## Summary
- return `Result` in file hashing utility
- handle errors when hashing files
- clean up duplicate finding to not panic on join failures
- avoid unwraps while scanning files and when opening projects

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684884d13b94832caf796e5d89094499