### PR TITLE
Handle poisoned locks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,11 @@ impl eframe::App for FileKrakenApp {
                                     .pick_file();
 
                                 if let Some(file) = maybe_file {
-                                    try_connect_sqlite(self, file.to_str().unwrap());
+                                    if let Some(path) = file.to_str() {
+                                        try_connect_sqlite(self, path);
+                                    } else {
+                                        error_dialog("Invalid project path");
+                                    }
                                 }
                             }
                             ui.add_space(8.0);
@@ -80,7 +84,11 @@ impl eframe::App for FileKrakenApp {
                                     if !file.ends_with(".fkrproj") {
                                         file.set_extension("fkrproj");
                                     }
-                                    try_connect_sqlite(self, file.to_str().unwrap());
+                                    if let Some(path) = file.to_str() {
+                                        try_connect_sqlite(self, path);
+                                    } else {
+                                        error_dialog("Invalid project path");
+                                    }
                                 }
                             }
                         });

--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -3,10 +3,11 @@ use crate::state::file::{FileKrakenFile, FileKrakenFileType};
 use crate::state::location::{FileKrakenLocation, FileKrakenLocationType};
 use crate::state::AppState;
 use crate::utils::get_longest_parent_path;
+use crate::utils::locks::{lock_rw_read_or_exit, lock_rw_write_or_exit};
 use egui::ahash::HashMap;
 use std::cmp::max;
 use std::ops::DerefMut;
-use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockWriteGuard};
 
 #[derive(Default)]
 pub struct FindDuplicatesState {
@@ -48,15 +49,16 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
             .show();
         return Some(());
     }
-    app_state
-        .find_duplicates_processing
-        .duplicates
-        .write()
-        .ok()?
-        .clear();
+    if let Some(mut dups) =
+        lock_rw_write_or_exit(&app_state.find_duplicates_processing.duplicates, &app_state)
+    {
+        dups.clear();
+    } else {
+        return None;
+    }
 
     set_processing_message(&app_state, "Scanning for file size matches...".to_string());
-    let mut duplicate_file_sizes = find_duplicate_file_sizes(&app_state.sqlite)?;
+    let mut duplicate_file_sizes = find_duplicate_file_sizes(&app_state)?;
 
     let files_by_size_by_hash = Arc::new(RwLock::new(HashMap::default()));
     let mut duplicates_search_by_filesize_threads = vec![];
@@ -74,8 +76,10 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
         let sizes_checked_so_far = sizes_checked_so_far.clone();
         duplicates_search_by_filesize_threads.push(std::thread::spawn(move || {
             for duplicate_file_size in duplicate_file_size_chunk {
-                let mut files_by_size: Vec<FileKrakenFile> =
-                    get_files_by_size(&app_state, duplicate_file_size).unwrap();
+                let Some(mut files_by_size) = get_files_by_size(&app_state, duplicate_file_size)
+                else {
+                    continue;
+                };
                 let nr_files_by_size = files_by_size.len();
                 set_processing_message(
                     &app_state,
@@ -101,19 +105,22 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
                     let _app_state = app_state.clone();
                     threads.push(std::thread::spawn(move || {
                         for mut file in files {
-                            // calc hash
-                            file.hash = Some(_app_state.calculate_file_hash(&file.path));
-                            files_by_size_by_hash
-                                .write()
-                                .unwrap()
-                                .entry(file.hash.clone().unwrap())
-                                .or_insert(vec![])
-                                .push(file.clone());
+                            if let Some(hash) = _app_state.calculate_file_hash(&file.path) {
+                                file.hash = Some(hash.clone());
+                                files_by_size_by_hash
+                                    .write()
+                                    .unwrap()
+                                    .entry(hash)
+                                    .or_insert(vec![])
+                                    .push(file.clone());
+                            }
                         }
                     }));
                 }
                 for thread in threads {
-                    thread.join().expect("Failed to join hashing thread");
+                    if let Err(err) = thread.join() {
+                        log::error!("Hashing thread panicked: {:?}", err);
+                    }
                 }
                 *sizes_checked_so_far.write().unwrap() += 1.0;
             }
@@ -127,21 +134,32 @@ pub fn run_find_file_duplicates(app_state: Arc<AppState>) -> Option<()> {
         &app_state,
         "Checking file-hashes for duplicates...".to_string(),
     );
-    let files_by_size_by_hash_lock = files_by_size_by_hash.write().ok()?;
+    let files_by_size_by_hash_lock = match lock_rw_write_or_exit(&files_by_size_by_hash, &app_state)
+    {
+        Some(lock) => lock,
+        None => return None,
+    };
     for (_, files_by_size) in files_by_size_by_hash_lock.iter() {
-        for (_, files) in files_by_size.read().ok()?.iter() {
+        for (_, files) in match lock_rw_read_or_exit(files_by_size, &app_state) {
+            Some(l) => l,
+            None => return None,
+        }
+        .iter()
+        {
             if files.len() > 1 {
-                let mut duplicates_list = app_state
-                    .find_duplicates_processing
-                    .duplicates
-                    .write()
-                    .ok()?;
+                let mut duplicates_list = match lock_rw_write_or_exit(
+                    &app_state.find_duplicates_processing.duplicates,
+                    &app_state,
+                ) {
+                    Some(lock) => lock,
+                    None => return None,
+                };
 
                 let deletable_file = get_deletable_file(&app_state, &files);
-                let other_files = if deletable_file.is_some() {
+                let other_files = if let Some(ref deletable) = deletable_file {
                     files
                         .iter()
-                        .filter(|x| x.path != deletable_file.as_ref().unwrap().path)
+                        .filter(|x| x.path != deletable.path)
                         .cloned()
                         .collect()
                 } else {
@@ -174,7 +192,7 @@ fn get_deletable_file(
                     (
                         file.clone(),
                         get_longest_parent_path(&file.path, locations.iter())
-                            .map(|x| locations.iter().find(|loc| loc.path == x).unwrap().clone()),
+                            .and_then(|p| locations.iter().find(|loc| loc.path == p).cloned()),
                     )
                 })
                 .collect()
@@ -210,41 +228,35 @@ fn get_deletable_file(
 }
 
 fn get_files_by_size(app_state: &Arc<AppState>, size: u64) -> Option<Vec<FileKrakenFile>> {
-    let sqlite_lock = app_state.sqlite.lock().unwrap();
-    let mut files = vec![];
-
-    let mut sqlite_query = sqlite_lock
-        .as_ref()?
-        .prepare(
+    app_state.with_sqlite_conn(|conn| {
+        let mut stmt = conn.prepare(
             "SELECT \
         path, file_type, file_len, time_created, time_modified, hash_256 \
         FROM files \
         WHERE file_len = ?1",
-        )
-        .unwrap();
-    let mut select_files = sqlite_query.query([size]).ok()?;
-
-    while let Some(row) = select_files.next().ok()? {
-        let file_path: String = row.get(0).ok()?;
-        let file_type = match row.get::<usize, String>(1).ok()?.as_str() {
-            "normal" => FileKrakenFileType::Normal,
-            "archive" => FileKrakenFileType::Archive,
-            x => {
-                panic!("unknown file type {}", x)
-            }
-        };
-
-        files.push(FileKrakenFile {
-            path: file_path,
-            file_type,
-            file_len: row.get(2).ok()?,
-            time_created: row.get(3).ok()?,
-            time_modified: row.get(4).ok()?,
-            hash: row.get(5).ok()?,
-        });
-    }
-
-    Some(files)
+        )?;
+        let mut select_files = stmt.query([size])?;
+        let mut files = vec![];
+        while let Some(row) = select_files.next()? {
+            let file_path: String = row.get(0)?;
+            let file_type = match row.get::<usize, String>(1)?.as_str() {
+                "normal" => FileKrakenFileType::Normal,
+                "archive" => FileKrakenFileType::Archive,
+                x => {
+                    panic!("unknown file type {}", x)
+                }
+            };
+            files.push(FileKrakenFile {
+                path: file_path,
+                file_type,
+                file_len: row.get(2)?,
+                time_created: row.get(3)?,
+                time_modified: row.get(4)?,
+                hash: row.get(5)?,
+            });
+        }
+        Ok(files)
+    })
 }
 
 pub fn get_duplicates_processing_state(
@@ -258,23 +270,17 @@ pub fn set_processing_message(app_state: &Arc<AppState>, message: String) {
         FindDuplicatesStateType::Processing(message);
 }
 
-fn find_duplicate_file_sizes(
-    sqlite: &Arc<Mutex<Option<rusqlite::Connection>>>,
-) -> Option<Vec<u64>> {
-    let sqlite_lock = sqlite.lock().unwrap();
-    let mut find_duplicate_file_sizes = sqlite_lock
-        .as_ref()
-        .unwrap()
-        .prepare("SELECT file_len, COUNT(*) c FROM files f GROUP BY file_len HAVING c > 1")
-        .ok()?;
-    let mut find_duplicate_file_sizes_query = find_duplicate_file_sizes.query([]).ok()?;
-
-    let mut duplicate_file_sizes = vec![];
-    while let Some(row) = find_duplicate_file_sizes_query.next().ok()? {
-        duplicate_file_sizes.push(row.get(0).ok()?);
-    }
-
-    Some(duplicate_file_sizes)
+fn find_duplicate_file_sizes(app_state: &Arc<AppState>) -> Option<Vec<u64>> {
+    app_state.with_sqlite_conn(|conn| {
+        let mut stmt = conn
+            .prepare("SELECT file_len, COUNT(*) c FROM files f GROUP BY file_len HAVING c > 1")?;
+        let mut query = stmt.query([])?;
+        let mut sizes = vec![];
+        while let Some(row) = query.next()? {
+            sizes.push(row.get(0)?);
+        }
+        Ok(sizes)
+    })
 }
 
 pub fn delete_duplicate(app_state: &Arc<AppState>, duplicate: &FileKrakenDuplicate) {
@@ -286,14 +292,19 @@ pub fn delete_duplicate(app_state: &Arc<AppState>, duplicate: &FileKrakenDuplica
             .read()
             .unwrap();
 
-        duplicates_list
-            .iter()
-            .position(|x| {
-                x.deletable_file.as_ref().is_some_and(|file| {
-                    file.path == duplicate.deletable_file.as_ref().unwrap().path
-                })
+        match duplicates_list.iter().position(|x| {
+            x.deletable_file.as_ref().is_some_and(|file| {
+                duplicate
+                    .deletable_file
+                    .as_ref()
+                    .map(|d| d.path.as_str())
+                    .unwrap_or("")
+                    == file.path
             })
-            .unwrap()
+        }) {
+            Some(index) => index,
+            None => return,
+        }
     };
     {
         app_state
@@ -304,5 +315,7 @@ pub fn delete_duplicate(app_state: &Arc<AppState>, duplicate: &FileKrakenDuplica
             .remove(duplicate_index);
     }
 
-    app_state.remove_file(true, true, &duplicate.deletable_file.as_ref().unwrap().path);
+    if let Some(file) = duplicate.deletable_file.as_ref() {
+        app_state.remove_file(true, true, &file.path);
+    }
 }

--- a/src/processing/scan.rs
+++ b/src/processing/scan.rs
@@ -8,10 +8,13 @@ use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
 pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
-    let current_state = app_state
-        .get_location_clone(location_path)
-        .unwrap()
-        .location_state;
+    let current_state = match app_state.get_location_clone(location_path) {
+        Some(loc) => loc.location_state,
+        None => {
+            error_dialog(&format!("Location {location_path} not found"));
+            return;
+        }
+    };
     if current_state == FileKrakenLocationState::Scanning {
         return error_dialog("Already scanning this location");
     }
@@ -32,10 +35,17 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
                 } else {
                     FileKrakenFileType::Normal
                 };
-                let file_metadata = entry.metadata().expect(&format!(
-                    "Failed to get file metadata for file {:?}",
-                    entry.path()
-                ));
+                let file_metadata = match entry.metadata() {
+                    Ok(meta) => meta,
+                    Err(err) => {
+                        error!(
+                            "Failed to get file metadata for file {:?}: {}",
+                            entry.path(),
+                            err
+                        );
+                        continue;
+                    }
+                };
 
                 if let Some(file_path) = entry.path().to_str() {
                     app_state.add_file(
@@ -45,15 +55,15 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
                         file_metadata.len(),
                         file_metadata
                             .created()
-                            .unwrap()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or(std::time::Duration::new(0, 0))
+                            .ok()
+                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                            .unwrap_or_default()
                             .as_secs(),
                         file_metadata
                             .modified()
-                            .unwrap()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or(std::time::Duration::new(0, 0))
+                            .ok()
+                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                            .unwrap_or_default()
                             .as_secs(),
                         None,
                     );
@@ -83,18 +93,21 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
     }
 
     // check if files were removed
-    let files: Vec<String> = {
-        let sqlite_lock = app_state.sqlite.lock().unwrap();
-        let mut files_query = sqlite_lock
-            .as_ref()
-            .unwrap()
-            .prepare("SELECT path FROM files WHERE location_path = ?")
-            .unwrap();
-        files_query
-            .query_map(&[&location_path], |row| row.get(0))
-            .unwrap()
-            .map(|x| x.unwrap())
-            .collect()
+    // A failure to query the database here means the project state is no longer
+    // trustworthy. Notify the user and close the project on any error.
+    let files: Vec<String> = match app_state.with_sqlite_conn(|conn| {
+        let mut stmt = conn.prepare("SELECT path FROM files WHERE location_path = ?")?;
+        let rows = stmt.query_map([location_path], |row| row.get(0))?;
+        let mut out = Vec::new();
+        for row in rows {
+            if let Ok(p) = row {
+                out.push(p);
+            }
+        }
+        Ok(out)
+    }) {
+        Some(v) => v,
+        None => return,
     };
     for file in files {
         // check filesystem

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -1,6 +1,7 @@
-use crate::processing::find_duplicates::FindDuplicatesState;
+use crate::processing::find_duplicates::{FindDuplicatesState, FindDuplicatesStateType};
 use crate::state::file::{FileKrakenFile, FileKrakenFileType};
 use crate::state::location::{FileKrakenLocation, FileKrakenLocationState, FileKrakenLocationType};
+use crate::utils::dialogs::error_dialog;
 use crate::utils::get_longest_parent_path;
 use crate::utils::hashing::hash_file;
 use std::collections::HashMap;
@@ -120,41 +121,74 @@ impl AppState {
         Ok(())
     }
 
-    pub fn calculate_file_hash(&self, file_path: &str) -> String {
+    /// Acquire the SQLite connection mutex or exit the project on failure.
+    pub fn sqlite_lock_or_exit(
+        &self,
+    ) -> Option<std::sync::MutexGuard<'_, Option<rusqlite::Connection>>> {
+        match self.sqlite.lock() {
+            Ok(g) => Some(g),
+            Err(_) => {
+                error_dialog("Internal error: database lock poisoned. Closing project.");
+                self.close_project();
+                None
+            }
+        }
+    }
+
+    /// Execute a closure with a reference to the SQLite connection. If any
+    /// error occurs while accessing the connection or running the closure, the
+    /// project is closed and `None` is returned.
+    pub fn with_sqlite_conn<F, T>(&self, func: F) -> Option<T>
+    where
+        F: FnOnce(&rusqlite::Connection) -> rusqlite::Result<T>,
+    {
+        let guard = self.sqlite_lock_or_exit()?;
+        let conn = match guard.as_ref() {
+            Some(c) => c,
+            None => {
+                error_dialog("Internal error: database connection missing. Closing project.");
+                self.close_project();
+                return None;
+            }
+        };
+        match func(conn) {
+            Ok(val) => Some(val),
+            Err(err) => {
+                error_dialog(&format!("Database error: {err}. Closing project."));
+                self.close_project();
+                None
+            }
+        }
+    }
+
+    pub fn calculate_file_hash(&self, file_path: &str) -> Option<String> {
         // get file to check if its already hashed
-        let hash: String = self
-            .sqlite
-            .lock()
-            .unwrap()
-            .as_ref()
-            .expect("sqlite connection not set")
-            .query_row(
+        let hash: String = self.with_sqlite_conn(|conn| {
+            conn.query_row(
                 "SELECT hash_256 FROM files WHERE path = ?1;",
                 [file_path],
                 |x| x.get(0),
             )
-            .unwrap();
+        })?;
 
-        match hash.as_str() {
-            "NULL" => {
-                // calculate hash
-                let hash = hash_file(&file_path);
-
-                // update hash in sqlite
-                self.sqlite
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .expect("sqlite connection not set")
-                    .execute(
-                        "UPDATE files SET hash_256 = ?1 WHERE path = ?2;",
-                        [&hash, file_path],
-                    )
-                    .unwrap();
-
-                hash
+        if hash == "NULL" {
+            match hash_file(file_path) {
+                Ok(hash) => {
+                    let _ = self.with_sqlite_conn(|conn| {
+                        conn.execute(
+                            "UPDATE files SET hash_256 = ?1 WHERE path = ?2;",
+                            [&hash, file_path],
+                        )
+                    });
+                    Some(hash)
+                }
+                Err(err) => {
+                    error_dialog(&format!("Failed to hash file {file_path}: {err}"));
+                    None
+                }
             }
-            x => x.to_string(),
+        } else {
+            Some(hash)
         }
     }
 
@@ -520,5 +554,24 @@ impl AppState {
             .get(location)
             // clone the Arc reference of the Hashmap if it exists
             .map(|x| x.clone())
+    }
+
+    /// Close the currently open project and clear all in-memory state.
+    pub fn close_project(&self) {
+        if let Ok(mut sqlite) = self.sqlite.lock() {
+            *sqlite = None;
+        }
+        if let Ok(mut locations) = self.locations_list.write() {
+            locations.clear();
+        }
+        if let Ok(mut files) = self.files_by_location_by_path.write() {
+            files.clear();
+        }
+        if let Ok(mut dups) = self.find_duplicates_processing.duplicates.write() {
+            dups.clear();
+        }
+        if let Ok(mut state) = self.find_duplicates_processing.state.write() {
+            *state = FindDuplicatesStateType::None;
+        }
     }
 }

--- a/src/utils/hashing.rs
+++ b/src/utils/hashing.rs
@@ -1,12 +1,14 @@
 use sha2::{Digest, Sha256};
 use std::{fs, io};
 
-pub fn hash_file(file_path: &str) -> String {
+/// Calculate the SHA256 hash of a file.
+///
+/// Instead of panicking on IO errors, this function now
+/// returns a `Result` so callers can react appropriately.
+pub fn hash_file(file_path: &str) -> io::Result<String> {
     let mut hasher = Sha256::new();
-    let mut file =
-        fs::File::open(file_path).expect(&format!("Failed to open file {:?}", file_path));
-    let _bytes_written =
-        io::copy(&mut file, &mut hasher).expect(&format!("Failed to hash file {:?}", file_path));
+    let mut file = fs::File::open(file_path)?;
+    io::copy(&mut file, &mut hasher)?;
 
-    format!("{:X}", hasher.finalize())
+    Ok(format!("{:X}", hasher.finalize()))
 }

--- a/src/utils/locks.rs
+++ b/src/utils/locks.rs
@@ -1,0 +1,31 @@
+use crate::state::AppState;
+use crate::utils::dialogs::error_dialog;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+pub fn lock_rw_write_or_exit<'a, T>(
+    lock: &'a RwLock<T>,
+    app_state: &AppState,
+) -> Option<RwLockWriteGuard<'a, T>> {
+    match lock.write() {
+        Ok(guard) => Some(guard),
+        Err(_) => {
+            error_dialog("Internal error: lock poisoned. Closing project.");
+            app_state.close_project();
+            None
+        }
+    }
+}
+
+pub fn lock_rw_read_or_exit<'a, T>(
+    lock: &'a RwLock<T>,
+    app_state: &AppState,
+) -> Option<RwLockReadGuard<'a, T>> {
+    match lock.read() {
+        Ok(guard) => Some(guard),
+        Err(_) => {
+            error_dialog("Internal error: lock poisoned. Closing project.");
+            app_state.close_project();
+            None
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod dialogs;
 pub mod hashing;
+pub mod locks;
 mod parent_path;
 pub mod ui_elements;
 


### PR DESCRIPTION
## Summary
- rename helper functions to `lock_or_exit`
- add `with_sqlite_conn` to simplify DB calls
- use `with_sqlite_conn` in scanning and duplicate search
- rename sqlite lock helper

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_684884d13b94832caf796e5d89094499