### PR TITLE
Add hashing tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,6 +1422,7 @@ dependencies = [
  "rfd",
  "rusqlite",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ log = "0.4.22"
 rfd = "0.14.1"
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sha2 = "0.10.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/utils/hashing.rs
+++ b/src/utils/hashing.rs
@@ -12,3 +12,31 @@ pub fn hash_file(file_path: &str) -> io::Result<String> {
 
     Ok(format!("{:X}", hasher.finalize()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::hash_file;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_hash_file_success() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("sample.txt");
+        let mut file = File::create(&file_path).unwrap();
+        write!(file, "hello world").unwrap();
+
+        let hash = hash_file(file_path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            hash,
+            "B94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9"
+        );
+    }
+
+    #[test]
+    fn test_hash_file_not_found() {
+        let err = hash_file("/non/existent/path.txt").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+}


### PR DESCRIPTION
## Summary
- add dev-dependency `tempfile`
- test `hash_file` on success and failure

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68489e7b0a68832ca5b7cf2aa5e461a8