### PR TITLE
Ensure trailing newline in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ For now, File Kraken is still in development and there is no initial release yet
 To build and install directly from source, you can use
 
 `cargo install --git https://github.com/larsfroelich/file-kraken.git`
+


### PR DESCRIPTION
## Summary
- ensure installation section is neatly terminated
- append a newline at the end of README

## Testing
- `cargo test`
- `cargo clippy -- -D warnings` *(fails: collapsible_if, question_mark, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8b252dc832ca4f2c3257762edd1