### PR TITLE
Fix clippy errors

### DIFF
--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -165,20 +165,12 @@ fn detect_hashed_duplicates(
         "Checking file-hashes for duplicates...".to_string(),
     );
     for (_, files_by_size) in files_by_size_by_hash.iter() {
-        for (_, files) in match lock_rw_read_or_exit(files_by_size, app_state) {
-            Some(l) => l,
-            None => return None,
-        }
-        .iter()
-        {
+        for (_, files) in lock_rw_read_or_exit(files_by_size, app_state)?.iter() {
             if files.len() > 1 {
-                let mut duplicates_list = match lock_rw_write_or_exit(
+                let mut duplicates_list = lock_rw_write_or_exit(
                     &app_state.find_duplicates_processing.duplicates,
                     app_state,
-                ) {
-                    Some(lock) => lock,
-                    None => return None,
-                };
+                )?;
 
                 let deletable_file = get_deletable_file(app_state, files);
                 let other_files = if let Some(ref deletable) = deletable_file {
@@ -201,7 +193,7 @@ fn detect_hashed_duplicates(
                     duplicate
                         .deletable_file
                         .as_ref()
-                        .or_else(|| duplicate.other_files.get(0))
+                        .or_else(|| duplicate.other_files.first())
                         .map(|f| f.file_len)
                         .unwrap_or(0)
                 );
@@ -214,7 +206,7 @@ fn detect_hashed_duplicates(
 
 fn get_deletable_file(
     app_state: &Arc<AppState>,
-    files: &Vec<FileKrakenFile>,
+    files: &[FileKrakenFile],
 ) -> Option<FileKrakenFile> {
     let (preferred_file, normal_file) = {
         let file_locations: Vec<(FileKrakenFile, Option<FileKrakenLocation>)> = {

--- a/src/processing/scan.rs
+++ b/src/processing/scan.rs
@@ -21,12 +21,10 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
     app_state.modify_location_state(true, location_path, FileKrakenLocationState::Scanning);
 
     let mut failed_paths = Vec::new();
-    for entry in WalkDir::new(location_path) {
-        if let Ok(entry) = entry {
-            if entry.file_type.is_file() {
-                let file_type = if let Some(file_extension) =
-                    entry.path().extension().and_then(|x| x.to_str())
-                {
+    for entry in WalkDir::new(location_path).into_iter().flatten() {
+        if entry.file_type.is_file() {
+            let file_type =
+                if let Some(file_extension) = entry.path().extension().and_then(|x| x.to_str()) {
                     if [".tar.xz", ".zip", ".7z"].contains(&file_extension) {
                         FileKrakenFileType::Archive
                     } else {
@@ -35,45 +33,44 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
                 } else {
                     FileKrakenFileType::Normal
                 };
-                let file_metadata = match entry.metadata() {
-                    Ok(meta) => meta,
-                    Err(err) => {
-                        error!(
-                            "Failed to get file metadata for file {:?}: {}",
-                            entry.path(),
-                            err
-                        );
-                        continue;
-                    }
-                };
-
-                if let Some(file_path) = entry.path().to_str() {
-                    app_state.add_file(
-                        true,
-                        file_path,
-                        &file_type,
-                        file_metadata.len(),
-                        file_metadata
-                            .created()
-                            .ok()
-                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                            .unwrap_or_default()
-                            .as_secs(),
-                        file_metadata
-                            .modified()
-                            .ok()
-                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                            .unwrap_or_default()
-                            .as_secs(),
-                        None,
-                    );
-                } else {
+            let file_metadata = match entry.metadata() {
+                Ok(meta) => meta,
+                Err(err) => {
                     error!(
-                        "Failed to get file path for file {:?}",
-                        entry.path().to_string_lossy().as_ref()
+                        "Failed to get file metadata for file {:?}: {}",
+                        entry.path(),
+                        err
                     );
-                    failed_paths.push(entry.path().to_string_lossy().to_string());
+                    continue;
                 }
+            };
+
+            if let Some(file_path) = entry.path().to_str() {
+                app_state.add_file(
+                    true,
+                    file_path,
+                    &file_type,
+                    file_metadata.len(),
+                    file_metadata
+                        .created()
+                        .ok()
+                        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                        .unwrap_or_default()
+                        .as_secs(),
+                    file_metadata
+                        .modified()
+                        .ok()
+                        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                        .unwrap_or_default()
+                        .as_secs(),
+                    None,
+                );
+            } else {
+                error!(
+                    "Failed to get file path for file {:?}",
+                    entry.path().to_string_lossy().as_ref()
+                );
+                failed_paths.push(entry.path().to_string_lossy().to_string());
             }
         }
     }
@@ -98,13 +95,7 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
     let files: Vec<String> = match app_state.with_sqlite_conn(|conn| {
         let mut stmt = conn.prepare("SELECT path FROM files WHERE location_path = ?")?;
         let rows = stmt.query_map([location_path], |row| row.get(0))?;
-        let mut out = Vec::new();
-        for row in rows {
-            if let Ok(p) = row {
-                out.push(p);
-            }
-        }
-        Ok(out)
+        Ok(rows.flatten().collect())
     }) {
         Some(v) => v,
         None => return,

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -13,6 +13,7 @@ pub struct AppState {
     pub find_duplicates_processing: Arc<FindDuplicatesState>,
     pub sqlite: Arc<Mutex<Option<rusqlite::Connection>>>,
     locations_list: Arc<RwLock<Vec<FileKrakenLocation>>>,
+    #[allow(clippy::type_complexity)]
     files_by_location_by_path:
         Arc<RwLock<HashMap<String, Arc<RwLock<HashMap<String, FileKrakenFile>>>>>>,
 }
@@ -202,7 +203,7 @@ impl AppState {
             .unwrap()
             .iter_mut()
             .find(|x| x.path == location_path)
-            .expect(&format!("location {} not found", location_path))
+            .unwrap_or_else(|| panic!("location {} not found", location_path))
             .location_state = FileKrakenLocationState::Deleting;
 
         self.clear_location_files(persist_to_db, location_path);
@@ -241,8 +242,8 @@ impl AppState {
         }
 
         let file_parent_location_path =
-            get_longest_parent_path(&file_path, self.get_locations_list_readonly().iter())
-                .expect(&format!("no parent location found for file {}", file_path));
+            get_longest_parent_path(file_path, self.get_locations_list_readonly().iter())
+                .unwrap_or_else(|| panic!("no parent location found for file {}", file_path));
 
         self.files_by_location_by_path
             .read()
@@ -254,6 +255,7 @@ impl AppState {
             .remove(file_path);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_file(
         &self,
         persist_to_db: bool,
@@ -266,7 +268,7 @@ impl AppState {
     ) {
         let parent_location =
             get_longest_parent_path(file_path, self.get_locations_list_readonly().iter())
-                .expect(&format!("no parent location found for file {}", file_path));
+                .unwrap_or_else(|| panic!("no parent location found for file {}", file_path));
 
         self.add_file_to_location(
             persist_to_db,
@@ -280,6 +282,7 @@ impl AppState {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_file_to_location(
         &self,
         persist_to_db: bool,
@@ -322,7 +325,7 @@ impl AppState {
                     .ok()
             } {
                 if existing_location != location_path {
-                    self.remove_file(true, false, &file_path);
+                    self.remove_file(true, false, file_path);
                 }
             }
 
@@ -389,7 +392,7 @@ impl AppState {
             .unwrap()
             .iter()
             .find(|x| x.path == location_path)
-            .map(|x| x.clone())
+            .cloned()
     }
 
     pub fn get_locations_list_readonly(&self) -> RwLockReadGuard<'_, Vec<FileKrakenLocation>> {

--- a/src/tabs/tab_files/tab_files_duplicates.rs
+++ b/src/tabs/tab_files/tab_files_duplicates.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::collapsible_if)]
 use crate::processing::find_duplicates::{
     delete_duplicate, find_file_duplicates, get_duplicates_processing_state,
     set_processing_message, FindDuplicatesStateType,


### PR DESCRIPTION
## Summary
- fix `clippy` warnings by collapsing question marks and clean loops
- allow complex types in `AppState`
- simplify loops and borrowing in scanning logic
- silence collapsible-if lint

## Testing
- `cargo test`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6848a8841390832c9ce116fa69ee20d2