### PR TITLE
Add dark theme toggle

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use crate::tabs::tab_files::FileKrakenFileTabs;
 use crate::tabs::tab_locations::LocationTabState;
 use crate::tabs::FileKrakenMainTabs;
 use crate::utils::dialogs::error_dialog;
+use catppuccin_egui::{set_theme, LATTE, MOCHA};
 use egui::{Align, FontId, Layout, RichText, Vec2};
 use rfd::FileDialog;
 use std::sync::Arc;
@@ -28,6 +29,8 @@ pub struct FileKrakenApp {
 
     // main app state
     app_state: Arc<state::AppState>,
+
+    dark_theme: bool,
 }
 
 fn try_connect_sqlite(_self: &mut FileKrakenApp, path: &str) {
@@ -112,6 +115,15 @@ impl eframe::App for FileKrakenApp {
                     );
                 },
             );
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                if ui
+                    .button(if self.dark_theme { "☀️" } else { "🌙" })
+                    .clicked()
+                {
+                    self.dark_theme = !self.dark_theme;
+                    set_theme(ctx, if self.dark_theme { MOCHA } else { LATTE });
+                }
+            });
 
             ui.add_space(10.0);
             ui.horizontal(|ui| {


### PR DESCRIPTION
## Summary
- improve the UI by adding a dark/light theme toggle

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6849364ff83c832c876f9b0a1484f8ec