### PR TITLE
Expose border stroke in colored_box and update headers

### DIFF
--- a/src/tabs/tab_files/tab_files_duplicates.rs
+++ b/src/tabs/tab_files/tab_files_duplicates.rs
@@ -17,10 +17,15 @@ use std::thread;
 impl FileKrakenApp {
     pub fn files_tab_duplicates(&mut self, ui: &mut Ui) {
         ui.vertical(|ui| {
-            colored_box(ui, Color32::TRANSPARENT, |ui| {
-                ui.label("File Duplicates");
-            });
-            colored_box(ui, Color32::TRANSPARENT, |ui| {
+            colored_box(
+                ui,
+                Color32::TRANSPARENT,
+                egui::Stroke::new(1.0, egui::Color32::DARK_GRAY),
+                |ui| {
+                    ui.label("File Duplicates");
+                },
+            );
+            colored_box(ui, Color32::TRANSPARENT, egui::Stroke::NONE, |ui| {
                 ui.horizontal(|ui| {
                     ui.label("Status: ");
                     match self

--- a/src/tabs/tab_files/tab_files_overview.rs
+++ b/src/tabs/tab_files/tab_files_overview.rs
@@ -7,7 +7,7 @@ impl FileKrakenApp {
         ui.vertical(|ui| {
             colored_box(
                 ui,
-                egui::Color32::LIGHT_GRAY,
+                egui::Color32::TRANSPARENT,
                 egui::Stroke::new(1.0, egui::Color32::DARK_GRAY),
                 |ui| {
                     ui.label("Files Overview");

--- a/src/tabs/tab_files/tab_files_overview.rs
+++ b/src/tabs/tab_files/tab_files_overview.rs
@@ -5,10 +5,15 @@ use egui::Ui;
 impl FileKrakenApp {
     pub fn files_tab_overview(&mut self, ui: &mut Ui) {
         ui.vertical(|ui| {
-            colored_box(ui, egui::Color32::LIGHT_GRAY, |ui| {
-                ui.label("Files Overview");
-            });
-            colored_box(ui, egui::Color32::TRANSPARENT, |ui| {
+            colored_box(
+                ui,
+                egui::Color32::LIGHT_GRAY,
+                egui::Stroke::new(1.0, egui::Color32::DARK_GRAY),
+                |ui| {
+                    ui.label("Files Overview");
+                },
+            );
+            colored_box(ui, egui::Color32::TRANSPARENT, egui::Stroke::NONE, |ui| {
                 ui.horizontal(|ui| {
                     ui.label("Total Files: ");
                     let mut total_files = 0;

--- a/src/tabs/tab_locations.rs
+++ b/src/tabs/tab_locations.rs
@@ -35,10 +35,10 @@ impl FileKrakenApp {
 fn right_column(_self: &mut FileKrakenApp, ui: &mut Ui) {
     if let Some(selected_location) = &_self.tab_state_locations.selected_location {
         if let Some(location) = _self.app_state.get_location_clone(selected_location) {
-            colored_box(ui, egui::Color32::LIGHT_GRAY, |ui| {
+            colored_box(ui, egui::Color32::LIGHT_GRAY, egui::Stroke::NONE, |ui| {
                 ui.label("Location details:");
             });
-            colored_box(ui, egui::Color32::TRANSPARENT, |ui| {
+            colored_box(ui, egui::Color32::TRANSPARENT, egui::Stroke::NONE, |ui| {
                 ui.vertical(|ui| {
                     ui.horizontal(|ui| {
                         ui.label("Path:");
@@ -95,10 +95,10 @@ fn right_column(_self: &mut FileKrakenApp, ui: &mut Ui) {
                 });
             });
 
-            colored_box(ui, egui::Color32::LIGHT_GRAY, |ui| {
+            colored_box(ui, egui::Color32::LIGHT_GRAY, egui::Stroke::NONE, |ui| {
                 ui.label("Location status:");
             });
-            colored_box(ui, egui::Color32::TRANSPARENT, |ui| {
+            colored_box(ui, egui::Color32::TRANSPARENT, egui::Stroke::NONE, |ui| {
                 ui.vertical(|ui| {
                     ui.horizontal(|ui| {
                         ui.label("State:");
@@ -134,12 +134,12 @@ fn right_column(_self: &mut FileKrakenApp, ui: &mut Ui) {
                 });
             });
         } else {
-            colored_box(ui, egui::Color32::LIGHT_GRAY, |ui| {
+            colored_box(ui, egui::Color32::LIGHT_GRAY, egui::Stroke::NONE, |ui| {
                 ui.vertical_centered_justified(|ui| ui.label("Selected location not found"));
             });
         }
     } else {
-        colored_box(ui, egui::Color32::LIGHT_GRAY, |ui| {
+        colored_box(ui, egui::Color32::LIGHT_GRAY, egui::Stroke::NONE, |ui| {
             ui.vertical_centered_justified(|ui| ui.label("No location selected"));
         });
     }

--- a/src/utils/ui_elements.rs
+++ b/src/utils/ui_elements.rs
@@ -1,13 +1,14 @@
 use egui::{Label, Ui, WidgetText};
 
 pub fn colored_box(
-    ui: &mut Ui, 
-    color: egui::Color32, 
-    f: impl FnOnce(&mut Ui)
+    ui: &mut Ui,
+    color: egui::Color32,
+    stroke: egui::Stroke,
+    f: impl FnOnce(&mut Ui),
 ) {
     egui::Frame::none()
         .fill(color)
-        .stroke(egui::Stroke::NONE)
+        .stroke(stroke)
         .outer_margin(12.0)
         .inner_margin(6.0)
         .show(ui, f);


### PR DESCRIPTION
## Summary
- add `stroke` parameter to `colored_box`
- pass a visible stroke to the headers in Files/Duplicates and Files/Overview tabs
- update all other calls to use `Stroke::NONE`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6849784a9b4c832c984500ea4dbcff75