### PR TITLE
Delete persisted location rows in AppState::remove_location

### DIFF
--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -198,6 +198,7 @@ impl AppState {
     }
 
     pub fn remove_location(&self, persist_to_db: bool, location_path: &str) {
+        // mark location as deleting before removing any related state
         self.locations_list
             .write()
             .unwrap()
@@ -206,13 +207,27 @@ impl AppState {
             .unwrap_or_else(|| panic!("location {} not found", location_path))
             .location_state = FileKrakenLocationState::Deleting;
 
+        // remove dependent files first
         self.clear_location_files(persist_to_db, location_path);
 
+        // remove location row from sqlite when persistence is enabled
+        if persist_to_db {
+            self.sqlite
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("Sql connection not set")
+                .execute("DELETE FROM locations WHERE path = ?1;", [location_path])
+                .unwrap();
+        }
+
+        // clear in-memory file index for this location
         self.files_by_location_by_path
             .write()
             .unwrap()
             .remove(location_path);
 
+        // remove location from in-memory list
         let mut locations_list = self.locations_list.write().unwrap();
         locations_list.retain(|x| x.path != location_path);
     }
@@ -628,4 +643,50 @@ impl AppState {
             *state = FindDuplicatesStateType::None;
         }
     }
+}
+
+#[cfg(test)]
+fn temp_project_path() -> std::path::PathBuf {
+    let file = tempfile::Builder::new()
+        .prefix("file-kraken-remove-location")
+        .suffix(".fkproj")
+        .tempfile()
+        .unwrap();
+    file.into_temp_path().keep().unwrap()
+}
+
+#[test]
+fn remove_location_persisted_does_not_reload_from_same_project_file() {
+    let project_path = temp_project_path();
+    let project_path_str = project_path.to_str().unwrap();
+
+    // create a project with one location and one file
+    let app_state = AppState::default();
+    app_state.connect_sqlite(project_path_str).unwrap();
+    app_state.add_location(
+        true,
+        "/tmp/remove-me",
+        &FileKrakenLocationType::Normal,
+        &FileKrakenLocationState::Unscanned,
+    );
+    app_state.add_file_to_location(
+        true,
+        "/tmp/remove-me",
+        "/tmp/remove-me/file.txt",
+        &FileKrakenFileType::Normal,
+        10,
+        100,
+        100,
+        None,
+    );
+    app_state.remove_location(true, "/tmp/remove-me");
+    app_state.close_project();
+
+    // reconnect to same project and ensure location is gone
+    let reloaded = AppState::default();
+    reloaded.connect_sqlite(project_path_str).unwrap();
+    assert!(reloaded.get_locations_list_readonly().is_empty());
+    assert_eq!(reloaded.get_total_files_count(), 0);
+
+    std::fs::remove_file(project_path).unwrap();
 }


### PR DESCRIPTION
### Motivation
- Ensure that when a location is removed with `persist_to_db == true` the corresponding row in the `locations` table is removed so it does not reappear when reconnecting to the same project DB. 
- Preserve current in-memory behavior and safe ordering: mark location as `Deleting` and clear dependent files before removing the location row and in-memory entries.

### Description
- Updated `AppState::remove_location` to mark the location `Deleting`, call `clear_location_files`, then execute `DELETE FROM locations WHERE path = ?1;` when `persist_to_db` is `true`, and finally remove in-memory file-index and the location from `locations_list` in that order, all in `src/state/app_state.rs`.
- Added a small test helper `temp_project_path` and a focused test `remove_location_persisted_does_not_reload_from_same_project_file` that creates a project DB, adds a location and file, removes the location with persistence enabled, reconnects to the same project file, and asserts the location and files are not reloaded.

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo test` and all tests passed (including `remove_location_persisted_does_not_reload_from_same_project_file`).
- Ran `cargo clippy --all-targets --all-features` which completed successfully (with existing warnings unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df1b7f2fd0832ca284a4900166c995)