### PR TITLE
Add duplicate search filters and persistence

### DIFF
--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -4,15 +4,30 @@ use crate::state::location::{FileKrakenLocation, FileKrakenLocationType};
 use crate::state::AppState;
 use crate::utils::get_longest_parent_path;
 use crate::utils::locks::{lock_rw_read_or_exit, lock_rw_write_or_exit};
+use crate::utils::size_unit::SizeUnit;
 use egui::ahash::HashMap;
 use std::cmp::max;
 use std::ops::DerefMut;
 use std::sync::{Arc, RwLock, RwLockWriteGuard};
 
-#[derive(Default)]
 pub struct FindDuplicatesState {
     pub duplicates: RwLock<Vec<FileKrakenDuplicate>>,
     pub state: RwLock<FindDuplicatesStateType>,
+    pub min_file_size_input: RwLock<String>,
+    pub min_file_size_unit: RwLock<SizeUnit>,
+    pub include_same_location_duplicates: RwLock<bool>,
+}
+
+impl Default for FindDuplicatesState {
+    fn default() -> Self {
+        Self {
+            duplicates: RwLock::new(vec![]),
+            state: RwLock::new(FindDuplicatesStateType::None),
+            min_file_size_input: RwLock::new("0".to_string()),
+            min_file_size_unit: RwLock::new(SizeUnit::MB),
+            include_same_location_duplicates: RwLock::new(false),
+        }
+    }
 }
 
 #[derive(Default, PartialEq)]
@@ -297,10 +312,42 @@ pub fn set_processing_message(app_state: &Arc<AppState>, message: String) {
 }
 
 fn find_duplicate_file_sizes(app_state: &Arc<AppState>) -> Option<Vec<u64>> {
+    let min_size = {
+        let input = app_state
+            .find_duplicates_processing
+            .min_file_size_input
+            .read()
+            .unwrap();
+        let unit = app_state
+            .find_duplicates_processing
+            .min_file_size_unit
+            .read()
+            .unwrap();
+        input.parse::<u64>().unwrap_or(0) * unit.multiplier()
+    };
+
+    let include_same_location = *app_state
+        .find_duplicates_processing
+        .include_same_location_duplicates
+        .read()
+        .unwrap();
+
     app_state.with_sqlite_conn(|conn| {
-        let mut stmt = conn
-            .prepare("SELECT file_len, COUNT(*) c FROM files f GROUP BY file_len HAVING c > 1")?;
-        let mut query = stmt.query([])?;
+        let mut stmt = if include_same_location {
+            conn.prepare(
+                "SELECT file_len, COUNT(*) c FROM files f \
+                 WHERE file_len >= ?1 \
+                 GROUP BY file_len HAVING c > 1",
+            )?
+        } else {
+            conn.prepare(
+                "SELECT file_len, COUNT(*) c FROM files f \
+                 WHERE file_len >= ?1 \
+                 GROUP BY file_len HAVING c > 1 AND (SELECT COUNT(DISTINCT location_path) FROM files f2 WHERE f2.file_len = f.file_len) > 1",
+            )?
+        };
+
+        let mut query = stmt.query([min_size])?;
         let mut sizes = vec![];
         while let Some(row) = query.next()? {
             sizes.push(row.get(0)?);

--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -343,7 +343,7 @@ fn find_duplicate_file_sizes(app_state: &Arc<AppState>) -> Option<Vec<u64>> {
             conn.prepare(
                 "SELECT file_len, COUNT(*) c FROM files f \
                  WHERE file_len >= ?1 \
-                 GROUP BY file_len HAVING c > 1 AND (SELECT COUNT(DISTINCT location_path) FROM files f2 WHERE f2.file_len = f.file_len) > 1",
+                 GROUP BY file_len HAVING c > 1 AND COUNT(DISTINCT location_path) > 1",
             )?
         };
 

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -59,6 +59,13 @@ impl AppState {
                 ON files(hash_256);",
             [],
         )?;
+        connection.execute(
+            "CREATE TABLE IF NOT EXISTS settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );",
+            [],
+        )?;
         // Normalize legacy placeholder values to real SQL NULL
         connection.execute(
             "UPDATE files SET hash_256 = NULL WHERE hash_256 = 'NULL';",
@@ -126,6 +133,22 @@ impl AppState {
         }
 
         *self.sqlite.lock().unwrap().deref_mut() = Some(connection);
+
+        // Load settings
+        if let Some(min_size) = self.get_setting("min_file_size_input") {
+            *self.find_duplicates_processing.min_file_size_input.write().unwrap() = min_size;
+        }
+        if let Some(min_unit) = self.get_setting("min_file_size_unit") {
+            if let Ok(unit) = min_unit.parse() {
+                *self.find_duplicates_processing.min_file_size_unit.write().unwrap() = unit;
+            }
+        }
+        if let Some(include_same) = self.get_setting("include_same_location_duplicates") {
+            if let Ok(val) = include_same.parse() {
+                *self.find_duplicates_processing.include_same_location_duplicates.write().unwrap() = val;
+            }
+        }
+
         Ok(())
     }
 
@@ -203,6 +226,26 @@ impl AppState {
 
     pub fn is_sqlite_connected(&self) -> bool {
         self.sqlite.lock().unwrap().is_some()
+    }
+
+    pub fn get_setting(&self, key: &str) -> Option<String> {
+        self.with_sqlite_conn(|conn| {
+            conn.query_row(
+                "SELECT value FROM settings WHERE key = ?1;",
+                [key],
+                |row| row.get(0),
+            )
+        })
+    }
+
+    pub fn set_setting(&self, key: &str, value: &str) {
+        let _ = self.with_sqlite_conn(|conn| {
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES (?1, ?2) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value;",
+                rusqlite::params![key, value],
+            )
+        });
     }
 
     pub fn remove_location(&self, persist_to_db: bool, location_path: &str) {

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -249,6 +249,7 @@ impl AppState {
             // but we panic here to make sure we don't continue in a broken state if called from a background thread
             // that doesn't respect the project closing.
             log::error!("Failed to persist setting {}={}", key, value);
+            panic!("Failed to persist setting {}={}", key, value);
         }
     }
 

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -194,16 +194,20 @@ impl AppState {
 
     pub fn calculate_file_hash(&self, file_path: &str) -> Option<String> {
         // Check if this file has an existing hash in DB
-        let hash: Option<String> = self.with_sqlite_conn(|conn| {
-            conn.query_row(
-                "SELECT hash_256 FROM files WHERE path = ?1;",
-                [file_path],
-                |x| x.get(0),
-            )
+        let hash: Option<Option<String>> = self.with_sqlite_conn(|conn| {
+            let mut stmt = conn.prepare_cached("SELECT hash_256 FROM files WHERE path = ?1;")?;
+            let res = stmt.query_row([file_path], |row| row.get::<_, Option<String>>(0));
+            match res {
+                Ok(h) => Ok(Some(h)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(e),
+            }
         })?;
 
         if let Some(existing_hash) = hash {
-            return Some(existing_hash);
+            if existing_hash.is_some() {
+                return existing_hash;
+            }
         }
 
         // Compute hash only when DB has SQL NULL
@@ -229,13 +233,16 @@ impl AppState {
     }
 
     pub fn get_setting(&self, key: &str) -> Option<String> {
-        self.with_sqlite_conn(|conn| {
-            conn.query_row(
-                "SELECT value FROM settings WHERE key = ?1;",
-                [key],
-                |row| row.get(0),
-            )
-        })
+        let res: Option<Option<String>> = self.with_sqlite_conn(|conn| {
+            let mut stmt = conn.prepare_cached("SELECT value FROM settings WHERE key = ?1;")?;
+            let res = stmt.query_row([key], |row| row.get(0));
+            match res {
+                Ok(val) => Ok(Some(val)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(e),
+            }
+        });
+        res.flatten()
     }
 
     pub fn set_setting(&self, key: &str, value: &str) {
@@ -378,19 +385,18 @@ impl AppState {
 
         if persist_to_db {
             let file_hash = file.hash.clone();
-            if let Some((_, existing_location)) = {
-                self.sqlite
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .unwrap()
-                    .query_row(
-                        "SELECT path, location_path FROM files WHERE path = ?1;",
-                        [file_path],
-                        |x| Ok((x.get::<_, String>(0)?.to_string(), x.get::<_, String>(1)?)),
-                    )
-                    .ok()
-            } {
+            if let Some(Some((_, existing_location))) = self.with_sqlite_conn(|conn| {
+                let mut stmt =
+                    conn.prepare_cached("SELECT path, location_path FROM files WHERE path = ?1;")?;
+                let res = stmt.query_row([file_path], |x| {
+                    Ok((x.get::<_, String>(0)?.to_string(), x.get::<_, String>(1)?))
+                });
+                match res {
+                    Ok(val) => Ok(Some(val)),
+                    Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                    Err(e) => Err(e),
+                }
+            }) {
                 if existing_location != location_path {
                     self.remove_file(true, false, file_path);
                 }

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -4,6 +4,7 @@ use crate::state::location::{FileKrakenLocation, FileKrakenLocationState, FileKr
 use crate::utils::dialogs::error_dialog;
 use crate::utils::get_longest_parent_path;
 use crate::utils::hashing::hash_file;
+use rusqlite::OptionalExtension;
 use std::collections::HashMap;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
@@ -194,20 +195,14 @@ impl AppState {
 
     pub fn calculate_file_hash(&self, file_path: &str) -> Option<String> {
         // Check if this file has an existing hash in DB
-        let hash: Option<Option<String>> = self.with_sqlite_conn(|conn| {
-            let mut stmt = conn.prepare_cached("SELECT hash_256 FROM files WHERE path = ?1;")?;
-            let res = stmt.query_row([file_path], |row| row.get::<_, Option<String>>(0));
-            match res {
-                Ok(h) => Ok(Some(h)),
-                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-                Err(e) => Err(e),
-            }
-        })?;
+        let hash_result = self.with_sqlite_conn(|conn| {
+            conn.prepare_cached("SELECT hash_256 FROM files WHERE path = ?1;")?
+                .query_row([file_path], |row| row.get::<_, Option<String>>(0))
+                .optional()
+        });
 
-        if let Some(existing_hash) = hash {
-            if existing_hash.is_some() {
-                return existing_hash;
-            }
+        if let Some(Some(Some(existing_hash))) = hash_result {
+            return Some(existing_hash);
         }
 
         // Compute hash only when DB has SQL NULL
@@ -233,26 +228,28 @@ impl AppState {
     }
 
     pub fn get_setting(&self, key: &str) -> Option<String> {
-        let res: Option<Option<String>> = self.with_sqlite_conn(|conn| {
-            let mut stmt = conn.prepare_cached("SELECT value FROM settings WHERE key = ?1;")?;
-            let res = stmt.query_row([key], |row| row.get(0));
-            match res {
-                Ok(val) => Ok(Some(val)),
-                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-                Err(e) => Err(e),
-            }
-        });
-        res.flatten()
+        self.with_sqlite_conn(|conn| {
+            conn.prepare_cached("SELECT value FROM settings WHERE key = ?1;")?
+                .query_row([key], |row| row.get(0))
+                .optional()
+        })
+        .flatten()
     }
 
     pub fn set_setting(&self, key: &str, value: &str) {
-        let _ = self.with_sqlite_conn(|conn| {
+        let res = self.with_sqlite_conn(|conn| {
             conn.execute(
                 "INSERT INTO settings (key, value) VALUES (?1, ?2) \
                  ON CONFLICT(key) DO UPDATE SET value = excluded.value;",
                 rusqlite::params![key, value],
             )
         });
+        if res.is_none() {
+            // with_sqlite_conn already shows an error dialog and closes the project
+            // but we panic here to make sure we don't continue in a broken state if called from a background thread
+            // that doesn't respect the project closing.
+            log::error!("Failed to persist setting {}={}", key, value);
+        }
     }
 
     pub fn remove_location(&self, persist_to_db: bool, location_path: &str) {
@@ -386,16 +383,11 @@ impl AppState {
         if persist_to_db {
             let file_hash = file.hash.clone();
             if let Some(Some((_, existing_location))) = self.with_sqlite_conn(|conn| {
-                let mut stmt =
-                    conn.prepare_cached("SELECT path, location_path FROM files WHERE path = ?1;")?;
-                let res = stmt.query_row([file_path], |x| {
-                    Ok((x.get::<_, String>(0)?.to_string(), x.get::<_, String>(1)?))
-                });
-                match res {
-                    Ok(val) => Ok(Some(val)),
-                    Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-                    Err(e) => Err(e),
-                }
+                conn.prepare_cached("SELECT path, location_path FROM files WHERE path = ?1;")?
+                    .query_row([file_path], |x| {
+                        Ok((x.get::<_, String>(0)?.to_string(), x.get::<_, String>(1)?))
+                    })
+                    .optional()
             }) {
                 if existing_location != location_path {
                     self.remove_file(true, false, file_path);

--- a/src/tabs/tab_files/tab_files_duplicates.rs
+++ b/src/tabs/tab_files/tab_files_duplicates.rs
@@ -3,6 +3,7 @@ use crate::processing::find_duplicates::{
     delete_duplicate, find_file_duplicates, get_duplicates_processing_state,
     set_processing_message, FindDuplicatesStateType,
 };
+use crate::utils::size_unit::SizeUnit;
 use crate::state::duplicate::FileKrakenDuplicate;
 use crate::state::AppState;
 use crate::utils::ui_elements::{colored_box, unselectable_label};
@@ -28,14 +29,8 @@ impl FileKrakenApp {
             colored_box(ui, Color32::TRANSPARENT, egui::Stroke::NONE, |ui| {
                 ui.horizontal(|ui| {
                     ui.label("Status: ");
-                    match self
-                        .app_state
-                        .find_duplicates_processing
-                        .state
-                        .read()
-                        .unwrap()
-                        .deref()
-                    {
+                    let state = self.app_state.find_duplicates_processing.state.read().unwrap();
+                    match state.deref() {
                         FindDuplicatesStateType::None => {
                             ui.label("Idle");
                             if ui.button("Find Duplicates").clicked() {
@@ -63,6 +58,87 @@ impl FileKrakenApp {
                             }
                         }
                     }
+
+                    let is_processing = matches!(*state, FindDuplicatesStateType::Processing(_));
+                    ui.add_enabled_ui(!is_processing, |ui| {
+                        ui.add_space(20.0);
+                        ui.label("Min file size:");
+                        let mut min_size_input = self
+                            .app_state
+                            .find_duplicates_processing
+                            .min_file_size_input
+                            .read()
+                            .unwrap()
+                            .clone();
+                        if ui
+                            .add(
+                                egui::TextEdit::singleline(&mut min_size_input)
+                                    .desired_width(100.0),
+                            )
+                            .changed()
+                        {
+                            // only allow numbers
+                            if min_size_input.chars().all(|c| c.is_ascii_digit()) {
+                                *self
+                                    .app_state
+                                    .find_duplicates_processing
+                                    .min_file_size_input
+                                    .write()
+                                    .unwrap() = min_size_input.clone();
+                                self.app_state
+                                    .set_setting("min_file_size_input", &min_size_input);
+                            }
+                        }
+
+                        let mut min_size_unit = *self
+                            .app_state
+                            .find_duplicates_processing
+                            .min_file_size_unit
+                            .read()
+                            .unwrap();
+                        egui::ComboBox::from_id_source("min_file_size_unit")
+                            .selected_text(min_size_unit.to_string())
+                            .show_ui(ui, |ui| {
+                                for unit in SizeUnit::all() {
+                                    if ui
+                                        .selectable_value(&mut min_size_unit, unit, unit.to_string())
+                                        .clicked()
+                                    {
+                                        *self
+                                            .app_state
+                                            .find_duplicates_processing
+                                            .min_file_size_unit
+                                            .write()
+                                            .unwrap() = unit;
+                                        self.app_state
+                                            .set_setting("min_file_size_unit", &unit.to_string());
+                                    }
+                                }
+                            });
+
+                        ui.add_space(20.0);
+                        let mut include_same = *self
+                            .app_state
+                            .find_duplicates_processing
+                            .include_same_location_duplicates
+                            .read()
+                            .unwrap();
+                        if ui
+                            .checkbox(&mut include_same, "Include same-location duplicates")
+                            .clicked()
+                        {
+                            *self
+                                .app_state
+                                .find_duplicates_processing
+                                .include_same_location_duplicates
+                                .write()
+                                .unwrap() = include_same;
+                            self.app_state.set_setting(
+                                "include_same_location_duplicates",
+                                &include_same.to_string(),
+                            );
+                        }
+                    });
                 });
                 ui.separator();
                 {

--- a/src/tabs/tab_files/tab_files_duplicates.rs
+++ b/src/tabs/tab_files/tab_files_duplicates.rs
@@ -29,8 +29,7 @@ impl FileKrakenApp {
             colored_box(ui, Color32::TRANSPARENT, egui::Stroke::NONE, |ui| {
                 ui.horizontal(|ui| {
                     ui.label("Status: ");
-                    let state = self.app_state.find_duplicates_processing.state.read().unwrap();
-                    match state.deref() {
+                    match self.app_state.find_duplicates_processing.state.read().unwrap().deref() {
                         FindDuplicatesStateType::None => {
                             ui.label("Idle");
                             if ui.button("Find Duplicates").clicked() {
@@ -59,7 +58,10 @@ impl FileKrakenApp {
                         }
                     }
 
-                    let is_processing = matches!(*state, FindDuplicatesStateType::Processing(_));
+                    let is_processing = matches!(
+                        *self.app_state.find_duplicates_processing.state.read().unwrap(),
+                        FindDuplicatesStateType::Processing(_)
+                    );
                     ui.add_enabled_ui(!is_processing, |ui| {
                         ui.add_space(20.0);
                         ui.label("Min file size:");

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod dialogs;
 pub mod hashing;
 pub mod locks;
 mod parent_path;
+pub mod size_unit;
 pub mod ui_elements;
 
 pub use parent_path::get_longest_parent_path;

--- a/src/utils/size_unit.rs
+++ b/src/utils/size_unit.rs
@@ -1,0 +1,60 @@
+use std::str::FromStr;
+
+#[derive(Default, PartialEq, Clone, Copy, Debug)]
+pub enum SizeUnit {
+    B,
+    KB,
+    MB,
+    #[default]
+    GB,
+    TB,
+}
+
+impl SizeUnit {
+    pub fn multiplier(&self) -> u64 {
+        match self {
+            SizeUnit::B => 1,
+            SizeUnit::KB => 1024,
+            SizeUnit::MB => 1024 * 1024,
+            SizeUnit::GB => 1024 * 1024 * 1024,
+            SizeUnit::TB => 1024 * 1024 * 1024 * 1024,
+        }
+    }
+
+    pub fn all() -> [SizeUnit; 5] {
+        [
+            SizeUnit::B,
+            SizeUnit::KB,
+            SizeUnit::MB,
+            SizeUnit::GB,
+            SizeUnit::TB,
+        ]
+    }
+}
+
+impl std::fmt::Display for SizeUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SizeUnit::B => write!(f, "B"),
+            SizeUnit::KB => write!(f, "KB"),
+            SizeUnit::MB => write!(f, "MB"),
+            SizeUnit::GB => write!(f, "GB"),
+            SizeUnit::TB => write!(f, "TB"),
+        }
+    }
+}
+
+impl FromStr for SizeUnit {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "B" => Ok(SizeUnit::B),
+            "KB" => Ok(SizeUnit::KB),
+            "MB" => Ok(SizeUnit::MB),
+            "GB" => Ok(SizeUnit::GB),
+            "TB" => Ok(SizeUnit::TB),
+            _ => Err(()),
+        }
+    }
+}


### PR DESCRIPTION
Implemented a minimum file size filter and a same-location duplicate filter for the File Duplicates tab.

Key changes:
- Created `src/utils/size_unit.rs` to handle file size units and multipliers.
- Added `settings` table to the database for persisting user preferences.
- Modified `find_file_duplicates` logic to incorporate the new filters directly in the SQL query.
- Updated the UI in `tab_files_duplicates.rs` with a numeric input, unit dropdown, and a checkbox.
- Ensured settings are loaded on project connection and saved on change.

---
*PR created automatically by Jules for task [3521452282561005977](https://jules.google.com/task/3521452282561005977) started by @larsfroelich*