### PR TITLE
Optimize File Hashing and Threading Performance

### DIFF
--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -8,6 +8,7 @@ use crate::utils::size_unit::SizeUnit;
 use egui::ahash::HashMap;
 use std::cmp::max;
 use std::ops::DerefMut;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock, RwLockWriteGuard};
 
 pub struct FindDuplicatesState {
@@ -94,70 +95,65 @@ type FilesBySizeByHash = HashMap<u64, Arc<RwLock<HashMap<String, Vec<FileKrakenF
 
 fn hash_potential_duplicates(
     app_state: Arc<AppState>,
-    mut duplicate_file_sizes: Vec<u64>,
+    duplicate_file_sizes: Vec<u64>,
 ) -> Option<FilesBySizeByHash> {
     let files_by_size_by_hash = Arc::new(RwLock::new(HashMap::default()));
-    let mut threads = Vec::new();
-    let nr_total_sizes_to_check = duplicate_file_sizes.len();
-    let chunk_size = nr_total_sizes_to_check / 16;
-    let sizes_checked_so_far = Arc::new(RwLock::new(0f64));
+    let mut files_to_hash = Vec::new();
+    for size in duplicate_file_sizes {
+        if let Some(files) = get_files_by_size(&app_state, size) {
+            for file in files {
+                files_to_hash.push((size, file));
+            }
+        }
+    }
 
-    for duplicate_file_size_chunk in duplicate_file_sizes
-        .chunks_mut(max(1, chunk_size))
-        .map(|x| x.to_owned())
+    let nr_total = files_to_hash.len();
+    if nr_total == 0 {
+        return Some(HashMap::default());
+    }
+
+    let num_threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    let hashed_count = Arc::new(AtomicUsize::new(0));
+    let mut threads = Vec::new();
+
+    for chunk in files_to_hash
+        .chunks(max(1, nr_total / num_threads))
+        .map(|c| c.to_vec())
     {
         let app_state = app_state.clone();
         let files_by_size_by_hash = files_by_size_by_hash.clone();
-        let nr_total_sizes_to_check = nr_total_sizes_to_check as f64;
-        let sizes_checked_so_far = sizes_checked_so_far.clone();
+        let hashed_count = hashed_count.clone();
         threads.push(std::thread::spawn(move || {
-            for duplicate_file_size in duplicate_file_size_chunk {
-                let Some(mut files_by_size) = get_files_by_size(&app_state, duplicate_file_size)
-                else {
-                    continue;
-                };
-                let nr_files_by_size = files_by_size.len();
-                set_processing_message(
-                    &app_state,
-                    format!(
-                        "{:.2}% | Calculating hashes for {} files of size {}",
-                        *sizes_checked_so_far.read().unwrap() * 100.0 / nr_total_sizes_to_check,
-                        nr_files_by_size,
-                        duplicate_file_size
-                    ),
-                );
-                let mut hashing_threads = Vec::new();
-                for files in files_by_size
-                    .chunks_mut(max(1, nr_files_by_size / 4))
-                    .map(|x| x.to_owned())
-                {
-                    let files_by_size_by_hash = files_by_size_by_hash
+            for (size, mut file) in chunk {
+                let current = hashed_count.fetch_add(1, Ordering::SeqCst);
+                if current % 10 == 0 {
+                    set_processing_message(
+                        &app_state,
+                        format!(
+                            "{:.2}% | Hashing file {}/{}",
+                            current as f64 * 100.0 / nr_total as f64,
+                            current,
+                            nr_total
+                        ),
+                    );
+                }
+                if let Some(hash) = app_state.calculate_file_hash(&file.path) {
+                    file.hash = Some(hash.clone());
+                    let size_entry = {
+                        let mut map = files_by_size_by_hash.write().unwrap();
+                        map.entry(size)
+                            .or_insert_with(|| Arc::new(RwLock::new(HashMap::default())))
+                            .clone()
+                    };
+                    size_entry
                         .write()
                         .unwrap()
-                        .entry(duplicate_file_size)
-                        .or_insert_with(|| Arc::new(RwLock::new(HashMap::default())))
-                        .clone();
-                    let _app_state = app_state.clone();
-                    hashing_threads.push(std::thread::spawn(move || {
-                        for mut file in files {
-                            if let Some(hash) = _app_state.calculate_file_hash(&file.path) {
-                                file.hash = Some(hash.clone());
-                                files_by_size_by_hash
-                                    .write()
-                                    .unwrap()
-                                    .entry(hash)
-                                    .or_insert(Vec::new())
-                                    .push(file.clone());
-                            }
-                        }
-                    }));
+                        .entry(hash)
+                        .or_insert(Vec::new())
+                        .push(file);
                 }
-                for thread in hashing_threads {
-                    if let Err(err) = thread.join() {
-                        log::error!("Hashing thread panicked: {:?}", err);
-                    }
-                }
-                *sizes_checked_so_far.write().unwrap() += 1.0;
             }
         }));
     }

--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -6,10 +6,9 @@ use crate::utils::get_longest_parent_path;
 use crate::utils::locks::{lock_rw_read_or_exit, lock_rw_write_or_exit};
 use crate::utils::size_unit::SizeUnit;
 use egui::ahash::HashMap;
-use std::cmp::max;
 use std::ops::DerefMut;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, RwLock, RwLockWriteGuard};
+use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
 
 pub struct FindDuplicatesState {
     pub duplicates: RwLock<Vec<FileKrakenDuplicate>>,
@@ -117,43 +116,52 @@ fn hash_potential_duplicates(
         .unwrap_or(4);
     let hashed_count = Arc::new(AtomicUsize::new(0));
     let mut threads = Vec::new();
+    // Sort ascending so pop() takes the largest files first for better workload balancing
+    files_to_hash.sort_by_key(|(size, _)| *size);
+    let tasks = Arc::new(Mutex::new(files_to_hash));
 
-    for chunk in files_to_hash
-        .chunks(max(1, nr_total / num_threads))
-        .map(|c| c.to_vec())
-    {
+    for _ in 0..num_threads {
         let app_state = app_state.clone();
         let files_by_size_by_hash = files_by_size_by_hash.clone();
         let hashed_count = hashed_count.clone();
-        threads.push(std::thread::spawn(move || {
-            for (size, mut file) in chunk {
-                let current = hashed_count.fetch_add(1, Ordering::SeqCst);
-                if current % 10 == 0 {
-                    set_processing_message(
-                        &app_state,
-                        format!(
-                            "{:.2}% | Hashing file {}/{}",
-                            current as f64 * 100.0 / nr_total as f64,
-                            current,
-                            nr_total
-                        ),
-                    );
-                }
-                if let Some(hash) = app_state.calculate_file_hash(&file.path) {
-                    file.hash = Some(hash.clone());
-                    let size_entry = {
-                        let mut map = files_by_size_by_hash.write().unwrap();
-                        map.entry(size)
-                            .or_insert_with(|| Arc::new(RwLock::new(HashMap::default())))
-                            .clone()
-                    };
-                    size_entry
-                        .write()
-                        .unwrap()
-                        .entry(hash)
-                        .or_insert(Vec::new())
-                        .push(file);
-                }
+        let tasks = tasks.clone();
+        threads.push(std::thread::spawn(move || loop {
+            let task = {
+                let mut tasks_lock = tasks.lock().unwrap();
+                tasks_lock.pop()
+            };
+
+            let (size, mut file) = match task {
+                Some(t) => t,
+                None => break,
+            };
+
+            let current = hashed_count.fetch_add(1, Ordering::SeqCst);
+            if current % 10 == 0 {
+                set_processing_message(
+                    &app_state,
+                    format!(
+                        "{:.2}% | Hashing file {}/{}",
+                        (current + 1) as f64 * 100.0 / nr_total as f64,
+                        current + 1,
+                        nr_total
+                    ),
+                );
+            }
+            if let Some(hash) = app_state.calculate_file_hash(&file.path) {
+                file.hash = Some(hash.clone());
+                let size_entry = {
+                    let mut map = files_by_size_by_hash.write().unwrap();
+                    map.entry(size)
+                        .or_insert_with(|| Arc::new(RwLock::new(HashMap::default())))
+                        .clone()
+                };
+                size_entry
+                    .write()
+                    .unwrap()
+                    .entry(hash)
+                    .or_insert(Vec::new())
+                    .push(file);
             }
         }));
     }

--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -7,7 +7,7 @@ use crate::utils::locks::{lock_rw_read_or_exit, lock_rw_write_or_exit};
 use crate::utils::size_unit::SizeUnit;
 use egui::ahash::HashMap;
 use std::ops::DerefMut;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
 
 pub struct FindDuplicatesState {
@@ -107,6 +107,7 @@ fn hash_potential_duplicates(
     }
 
     let nr_total = files_to_hash.len();
+    let total_bytes: u64 = files_to_hash.iter().map(|(size, _)| *size).sum();
     if nr_total == 0 {
         return Some(HashMap::default());
     }
@@ -115,6 +116,7 @@ fn hash_potential_duplicates(
         .map(|n| n.get())
         .unwrap_or(4);
     let hashed_count = Arc::new(AtomicUsize::new(0));
+    let hashed_bytes = Arc::new(AtomicU64::new(0));
     let mut threads = Vec::new();
     // Sort ascending so pop() takes the largest files first for better workload balancing
     files_to_hash.sort_by_key(|(size, _)| *size);
@@ -124,6 +126,7 @@ fn hash_potential_duplicates(
         let app_state = app_state.clone();
         let files_by_size_by_hash = files_by_size_by_hash.clone();
         let hashed_count = hashed_count.clone();
+        let hashed_bytes = hashed_bytes.clone();
         let tasks = tasks.clone();
         threads.push(std::thread::spawn(move || loop {
             let task = {
@@ -137,17 +140,32 @@ fn hash_potential_duplicates(
             };
 
             let current = hashed_count.fetch_add(1, Ordering::SeqCst);
-            if current % 10 == 0 {
-                set_processing_message(
-                    &app_state,
-                    format!(
-                        "{:.2}% | Hashing file {}/{}",
-                        (current + 1) as f64 * 100.0 / nr_total as f64,
-                        current + 1,
-                        nr_total
-                    ),
-                );
-            }
+            let current_bytes = hashed_bytes.fetch_add(size, Ordering::SeqCst) + size;
+
+            let total_gb = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+            let current_gb = current_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+            let progress_msg = if total_gb >= 1.0 {
+                format!(
+                    "{:.2}% | Hashing file {}/{} ({:.2}/{:.2} GB)",
+                    (current + 1) as f64 * 100.0 / nr_total as f64,
+                    current + 1,
+                    nr_total,
+                    current_gb,
+                    total_gb
+                )
+            } else {
+                format!(
+                    "{:.2}% | Hashing file {}/{} ({:.2}/{:.2} MB)",
+                    (current + 1) as f64 * 100.0 / nr_total as f64,
+                    current + 1,
+                    nr_total,
+                    current_bytes as f64 / (1024.0 * 1024.0),
+                    total_bytes as f64 / (1024.0 * 1024.0)
+                )
+            };
+
+            set_processing_message(&app_state, progress_msg);
             if let Some(hash) = app_state.calculate_file_hash(&file.path) {
                 file.hash = Some(hash.clone());
                 let size_entry = {

--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -145,10 +145,11 @@ fn hash_potential_duplicates(
             let total_gb = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
             let current_gb = current_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
 
+            let progress_pct = current_bytes as f64 * 100.0 / total_bytes as f64;
             let progress_msg = if total_gb >= 1.0 {
                 format!(
                     "{:.2}% | Hashing file {}/{} ({:.2}/{:.2} GB)",
-                    (current + 1) as f64 * 100.0 / nr_total as f64,
+                    progress_pct,
                     current + 1,
                     nr_total,
                     current_gb,
@@ -157,7 +158,7 @@ fn hash_potential_duplicates(
             } else {
                 format!(
                     "{:.2}% | Hashing file {}/{} ({:.2}/{:.2} MB)",
-                    (current + 1) as f64 * 100.0 / nr_total as f64,
+                    progress_pct,
                     current + 1,
                     nr_total,
                     current_bytes as f64 / (1024.0 * 1024.0),

--- a/src/utils/hashing.rs
+++ b/src/utils/hashing.rs
@@ -10,7 +10,7 @@ pub fn hash_file(file_path: &str) -> io::Result<String> {
 
     let mut hasher = Sha256::new();
     let mut file = fs::File::open(file_path)?;
-    let mut buffer = vec![0; 4 * 1024 * 1024]; // 4MB buffer
+    let mut buffer = vec![0; 8 * 1024 * 1024]; // 8MB buffer
 
     loop {
         let count = file.read(&mut buffer)?;

--- a/src/utils/hashing.rs
+++ b/src/utils/hashing.rs
@@ -6,9 +6,19 @@ use std::{fs, io};
 /// Instead of panicking on IO errors, this function now
 /// returns a `Result` so callers can react appropriately.
 pub fn hash_file(file_path: &str) -> io::Result<String> {
+    use std::io::Read;
+
     let mut hasher = Sha256::new();
     let mut file = fs::File::open(file_path)?;
-    io::copy(&mut file, &mut hasher)?;
+    let mut buffer = vec![0; 4 * 1024 * 1024]; // 4MB buffer
+
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
 
     Ok(format!("{:X}", hasher.finalize()))
 }


### PR DESCRIPTION
This PR improves the performance of file hashing, especially for large files, and optimizes the threading model used during duplicate detection.

Key changes:
1.  **Buffer Size**: Replaced `std::io::copy` (which uses an 8KB buffer) with a manual loop using a 4MB buffer in `src/utils/hashing.rs`.
2.  **Threading**: Simplified the nested thread spawning in `src/processing/find_duplicates.rs`. It now uses a single level of threading with a pool size matching the system's available parallelism.
3.  **Progress Tracking**: Switched to using an `AtomicUsize` to track and report progress more accurately during the parallel hashing phase.

These changes directly address the request for better efficiency when dealing with large files.

---
*PR created automatically by Jules for task [15536322111457351223](https://jules.google.com/task/15536322111457351223) started by @larsfroelich*