### PR TITLE
Fix duplicate search progress stuck at 100%

### DIFF
--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -115,8 +115,8 @@ fn hash_potential_duplicates(
     let num_threads = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4);
-    let hashed_count = Arc::new(AtomicUsize::new(0));
-    let hashed_bytes = Arc::new(AtomicU64::new(0));
+    let started_count = Arc::new(AtomicUsize::new(0));
+    let completed_bytes = Arc::new(AtomicU64::new(0));
     let mut threads = Vec::new();
     // Sort ascending so pop() takes the largest files first for better workload balancing
     files_to_hash.sort_by_key(|(size, _)| *size);
@@ -125,8 +125,8 @@ fn hash_potential_duplicates(
     for _ in 0..num_threads {
         let app_state = app_state.clone();
         let files_by_size_by_hash = files_by_size_by_hash.clone();
-        let hashed_count = hashed_count.clone();
-        let hashed_bytes = hashed_bytes.clone();
+        let started_count = started_count.clone();
+        let completed_bytes = completed_bytes.clone();
         let tasks = tasks.clone();
         threads.push(std::thread::spawn(move || loop {
             let task = {
@@ -139,34 +139,38 @@ fn hash_potential_duplicates(
                 None => break,
             };
 
-            let current = hashed_count.fetch_add(1, Ordering::SeqCst);
-            let current_bytes = hashed_bytes.fetch_add(size, Ordering::SeqCst) + size;
+            let current_started = started_count.fetch_add(1, Ordering::SeqCst) + 1;
 
-            let total_gb = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
-            let current_gb = current_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+            let update_progress =
+                |app_state: &Arc<AppState>, completed_bytes: u64, started_idx: usize| {
+                    let total_gb = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+                    let completed_gb = completed_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
 
-            let progress_pct = current_bytes as f64 * 100.0 / total_bytes as f64;
-            let progress_msg = if total_gb >= 1.0 {
-                format!(
-                    "{:.2}% | Hashing file {}/{} ({:.2}/{:.2} GB)",
-                    progress_pct,
-                    current + 1,
-                    nr_total,
-                    current_gb,
-                    total_gb
-                )
-            } else {
-                format!(
-                    "{:.2}% | Hashing file {}/{} ({:.2}/{:.2} MB)",
-                    progress_pct,
-                    current + 1,
-                    nr_total,
-                    current_bytes as f64 / (1024.0 * 1024.0),
-                    total_bytes as f64 / (1024.0 * 1024.0)
-                )
-            };
+                    let progress_pct = completed_bytes as f64 * 100.0 / total_bytes as f64;
+                    let progress_msg = if total_gb >= 1.0 {
+                        format!(
+                            "{:.2}% | Hashing file {}/{} ({:.2}/{:.2} GB)",
+                            progress_pct, started_idx, nr_total, completed_gb, total_gb
+                        )
+                    } else {
+                        format!(
+                            "{:.2}% | Hashing file {}/{} ({:.2}/{:.2} MB)",
+                            progress_pct,
+                            started_idx,
+                            nr_total,
+                            completed_bytes as f64 / (1024.0 * 1024.0),
+                            total_bytes as f64 / (1024.0 * 1024.0)
+                        )
+                    };
+                    set_processing_message(app_state, progress_msg);
+                };
 
-            set_processing_message(&app_state, progress_msg);
+            update_progress(
+                &app_state,
+                completed_bytes.load(Ordering::SeqCst),
+                current_started,
+            );
+
             if let Some(hash) = app_state.calculate_file_hash(&file.path) {
                 file.hash = Some(hash.clone());
                 let size_entry = {
@@ -182,6 +186,9 @@ fn hash_potential_duplicates(
                     .or_insert(Vec::new())
                     .push(file);
             }
+
+            let current_completed_bytes = completed_bytes.fetch_add(size, Ordering::SeqCst) + size;
+            update_progress(&app_state, current_completed_bytes, current_started);
         }));
     }
 

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -137,16 +137,28 @@ impl AppState {
 
         // Load settings
         if let Some(min_size) = self.get_setting("min_file_size_input") {
-            *self.find_duplicates_processing.min_file_size_input.write().unwrap() = min_size;
+            *self
+                .find_duplicates_processing
+                .min_file_size_input
+                .write()
+                .unwrap() = min_size;
         }
         if let Some(min_unit) = self.get_setting("min_file_size_unit") {
             if let Ok(unit) = min_unit.parse() {
-                *self.find_duplicates_processing.min_file_size_unit.write().unwrap() = unit;
+                *self
+                    .find_duplicates_processing
+                    .min_file_size_unit
+                    .write()
+                    .unwrap() = unit;
             }
         }
         if let Some(include_same) = self.get_setting("include_same_location_duplicates") {
             if let Ok(val) = include_same.parse() {
-                *self.find_duplicates_processing.include_same_location_duplicates.write().unwrap() = val;
+                *self
+                    .find_duplicates_processing
+                    .include_same_location_duplicates
+                    .write()
+                    .unwrap() = val;
             }
         }
 
@@ -659,6 +671,7 @@ impl AppState {
             });
     }
 
+    #[cfg(test)]
     pub fn get_files_by_location(
         &self,
         location: &str,

--- a/src/tabs/tab_files/tab_files_duplicates.rs
+++ b/src/tabs/tab_files/tab_files_duplicates.rs
@@ -3,9 +3,9 @@ use crate::processing::find_duplicates::{
     delete_duplicate, find_file_duplicates, get_duplicates_processing_state,
     set_processing_message, FindDuplicatesStateType,
 };
-use crate::utils::size_unit::SizeUnit;
 use crate::state::duplicate::FileKrakenDuplicate;
 use crate::state::AppState;
+use crate::utils::size_unit::SizeUnit;
 use crate::utils::ui_elements::{colored_box, unselectable_label};
 use crate::FileKrakenApp;
 use egui::{Color32, RichText, Ui};
@@ -306,13 +306,13 @@ fn table_row(app_state: &Arc<AppState>, row: &mut TableRow, duplicate: &FileKrak
     };
 
     row.col(|ui| {
-        if duplicate.deletable_file.is_some() {
+        if let Some(deletable_file) = &duplicate.deletable_file {
             if ui.button("🗑️").clicked()
                 && rfd::MessageDialog::new()
                     .set_title("Delete file?")
                     .set_description(format!(
                         "Are you sure you want to delete the file \"{}\"?",
-                        duplicate.deletable_file.as_ref().unwrap().path
+                        deletable_file.path
                     ))
                     .set_buttons(rfd::MessageButtons::YesNo)
                     .show()


### PR DESCRIPTION
Improved the accuracy of the duplicate-finding progress bar by calculating the completion percentage based on hashed bytes rather than started files. This prevents the UI from getting stuck at 100% while large files are still being processed. Also addressed some Clippy warnings and unused code.

---
*PR created automatically by Jules for task [6043394538849869770](https://jules.google.com/task/6043394538849869770) started by @larsfroelich*