### PR TITLE
Improve duplicates view to prioritize preferred locations

### DIFF
--- a/src/processing/find_duplicates.rs
+++ b/src/processing/find_duplicates.rs
@@ -1,6 +1,6 @@
 use crate::state::duplicate::{FileKrakenDuplicate, FileKrakenDuplicateType};
 use crate::state::file::{FileKrakenFile, FileKrakenFileType};
-use crate::state::location::{FileKrakenLocation, FileKrakenLocationType};
+use crate::state::location::FileKrakenLocationType;
 use crate::state::AppState;
 use crate::utils::get_longest_parent_path;
 use crate::utils::locks::{lock_rw_read_or_exit, lock_rw_write_or_exit};
@@ -217,84 +217,61 @@ fn detect_hashed_duplicates(
                     app_state,
                 )?;
 
-                let deletable_file = get_deletable_file(app_state, files);
-                let other_files = if let Some(ref deletable) = deletable_file {
-                    files
-                        .iter()
-                        .filter(|x| x.path != deletable.path)
-                        .cloned()
-                        .collect()
+                let (preferred_files, normal_files) = {
+                    let locations = app_state.get_locations_list_readonly();
+                    let mut preferred = Vec::new();
+                    let mut normal = Vec::new();
+
+                    for file in files {
+                        let location_type = get_longest_parent_path(&file.path, locations.iter())
+                            .and_then(|p| locations.iter().find(|loc| loc.path == p))
+                            .map(|loc| loc.location_type.clone())
+                            .unwrap_or(FileKrakenLocationType::Normal);
+
+                        if location_type == FileKrakenLocationType::Preferred {
+                            preferred.push(file.clone());
+                        } else {
+                            normal.push(file.clone());
+                        }
+                    }
+                    (preferred, normal)
+                };
+
+                if !preferred_files.is_empty() {
+                    let reference = preferred_files[0].clone();
+
+                    // Rows for other preferred files
+                    for other_preferred in preferred_files.iter().skip(1) {
+                        duplicates_list.push(FileKrakenDuplicate {
+                            deletable_file: None,
+                            other_files: vec![reference.clone(), other_preferred.clone()],
+                            duplicate_type: FileKrakenDuplicateType::ExactMatch,
+                        });
+                    }
+
+                    // Rows for normal files (deletable)
+                    for normal in &normal_files {
+                        duplicates_list.push(FileKrakenDuplicate {
+                            deletable_file: Some(normal.clone()),
+                            other_files: vec![reference.clone()],
+                            duplicate_type: FileKrakenDuplicateType::ExactMatch,
+                        });
+                    }
                 } else {
-                    files.clone()
-                };
-                let duplicate = FileKrakenDuplicate {
-                    other_files,
-                    deletable_file,
-                    duplicate_type: FileKrakenDuplicateType::ExactMatch,
-                };
-                log::trace!(
-                    "found duplicate type {:?} size {}",
-                    duplicate.duplicate_type,
-                    duplicate
-                        .deletable_file
-                        .as_ref()
-                        .or_else(|| duplicate.other_files.first())
-                        .map(|f| f.file_len)
-                        .unwrap_or(0)
-                );
-                duplicates_list.push(duplicate);
+                    // No preferred files, use first normal as reference
+                    let reference = normal_files[0].clone();
+                    for other_normal in normal_files.iter().skip(1) {
+                        duplicates_list.push(FileKrakenDuplicate {
+                            deletable_file: None,
+                            other_files: vec![reference.clone(), other_normal.clone()],
+                            duplicate_type: FileKrakenDuplicateType::ExactMatch,
+                        });
+                    }
+                }
             }
         }
     }
     Some(())
-}
-
-fn get_deletable_file(
-    app_state: &Arc<AppState>,
-    files: &[FileKrakenFile],
-) -> Option<FileKrakenFile> {
-    let (preferred_file, normal_file) = {
-        let file_locations: Vec<(FileKrakenFile, Option<FileKrakenLocation>)> = {
-            let locations = app_state.get_locations_list_readonly();
-            files
-                .iter()
-                .map(|file| {
-                    (
-                        file.clone(),
-                        get_longest_parent_path(&file.path, locations.iter())
-                            .and_then(|p| locations.iter().find(|loc| loc.path == p).cloned()),
-                    )
-                })
-                .collect()
-        };
-
-        (
-            file_locations
-                .iter()
-                .filter(|(_, location)| location.is_some())
-                .find(|(_, location)| {
-                    location
-                        .as_ref()
-                        .is_some_and(|loc| loc.location_type == FileKrakenLocationType::Preferred)
-                })
-                .map(|(file, _)| file.clone()),
-            file_locations
-                .iter()
-                .filter(|(_, location)| location.is_some())
-                .find(|(_, location)| {
-                    location
-                        .as_ref()
-                        .is_some_and(|loc| loc.location_type == FileKrakenLocationType::Normal)
-                })
-                .map(|(file, _)| file.clone()),
-        )
-    };
-
-    if preferred_file.is_some() && normal_file.is_some() {
-        normal_file
-    } else {
-        None
-    }
 }
 
 fn get_files_by_size(app_state: &Arc<AppState>, size: u64) -> Option<Vec<FileKrakenFile>> {

--- a/src/tabs/tab_files/tab_files_duplicates.rs
+++ b/src/tabs/tab_files/tab_files_duplicates.rs
@@ -259,10 +259,10 @@ impl FileKrakenApp {
                                     ui.label(RichText::new(" ").strong());
                                 });
                                 row.col(|ui| {
-                                    ui.label(RichText::new("Location path 1").strong());
+                                    ui.label(RichText::new("Location 1").strong());
                                 });
                                 row.col(|ui| {
-                                    ui.label(RichText::new("Location path 2").strong());
+                                    ui.label(RichText::new("Location 2").strong());
                                 });
                                 row.col(|ui| {
                                     ui.label(RichText::new("Type").strong());


### PR DESCRIPTION
This change improves the user experience of the duplicates tab by ensuring that when a file has a copy in a "Preferred" location, that copy is always shown in the first column ("Location 1") as a reference. Files that are eligible for deletion are shown in the second column ("Location 2"). Additionally, instead of grouping all copies into a single row, the application now displays pairwise comparisons, creating a new row for each duplicate copy. Column headers have also been simplified to "Location 1" and "Location 2".

---
*PR created automatically by Jules for task [7879755170365885443](https://jules.google.com/task/7879755170365885443) started by @larsfroelich*