### PR TITLE
Include hidden files during scan

### DIFF
--- a/src/processing/scan.rs
+++ b/src/processing/scan.rs
@@ -82,7 +82,11 @@ pub fn scan_location_files(app_state: Arc<AppState>, location_path: &str) {
 
     const BATCH_SIZE: usize = 1000;
 
-    for entry in WalkDir::new(location_path).into_iter().flatten() {
+    for entry in WalkDir::new(location_path)
+        .skip_hidden(false)
+        .into_iter()
+        .flatten()
+    {
         if entry.file_type.is_file() {
             let path = entry.path();
             let file_path = match path.to_str() {


### PR DESCRIPTION
The file-kraken scanner was skipping hidden files (those starting with a leading ".") because `jwalk::WalkDir` defaults to skipping them. This change explicitly enables scanning of hidden files by calling `.skip_hidden(false)` on the `WalkDir` instance.

Changes:
- Updated `src/processing/scan.rs` to include `.skip_hidden(false)` in the `WalkDir` iterator.
- Verified the fix with a temporary unit test that confirmed hidden files are now correctly discovered and added to the application state.
- Ran existing tests to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [13931855172893747220](https://jules.google.com/task/13931855172893747220) started by @larsfroelich*